### PR TITLE
🧪 Add test coverage for raylib_shims.c

### DIFF
--- a/build_tests.ps1
+++ b/build_tests.ps1
@@ -7,7 +7,7 @@ $ErrorActionPreference = "Stop"
 # Ensure bin/ exists
 New-Item -ItemType Directory -Force -Path "bin" | Out-Null
 
-$buildCmd = 'clang-cl /nologo /W3 /TC /D _CRT_SECURE_NO_WARNINGS /D WIN32_LEAN_AND_MEAN /I src /I tests/unity tests/test_main.c tests/test_utils.c tests/test_list.c tests/test_parse_range.c tests/test_export.c tests/unity/unity.c src/utils.c src/list.c src/range_parser.c src/export.c /Fe"bin/catnet_tests.exe" /link Ws2_32.lib'
+$buildCmd = 'clang-cl /nologo /W3 /TC /D _CRT_SECURE_NO_WARNINGS /D WIN32_LEAN_AND_MEAN /I src /I tests/unity tests/test_main.c tests/test_utils.c tests/test_list.c tests/test_parse_range.c tests/test_export.c tests/test_raylib_shims.c tests/unity/unity.c src/utils.c src/list.c src/range_parser.c src/export.c src/raylib_shims.c /Fe"bin/catnet_tests.exe" /link Ws2_32.lib'
 
 # Determine which compiler is available in PATH
 $cc = $null

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -6,6 +6,7 @@ void run_test_utils(void);
 void run_test_list(void);
 void run_test_parse_range(void);
 void run_test_export(void);
+void run_test_raylib_shims(void);
 
 /* Global setUp/tearDown required by Unity when compiling multiple test files */
 void setUp(void) {}
@@ -18,5 +19,6 @@ int main(void)
     run_test_list();
     run_test_parse_range();
     run_test_export();
+    run_test_raylib_shims();
     return UNITY_END();
 }

--- a/tests/test_raylib_shims.c
+++ b/tests/test_raylib_shims.c
@@ -1,0 +1,99 @@
+/* tests/test_raylib_shims.c */
+#include "unity/unity.h"
+#include <string.h>
+#include <stdio.h>
+#include "../src/raylib_shims.h"
+
+static void test_mem_alloc_free(void)
+{
+    void* ptr = MemAlloc(100);
+    TEST_ASSERT_NOT_NULL(ptr);
+    /* Should be zero initialized due to calloc */
+    char zeros[100] = {0};
+    TEST_ASSERT_EQUAL_MEMORY(zeros, ptr, 100);
+
+    ptr = MemRealloc(ptr, 200);
+    TEST_ASSERT_NOT_NULL(ptr);
+
+    MemFree(ptr);
+}
+
+static void test_file_data_save_load(void)
+{
+    const char* filename = "test_data.bin";
+    unsigned char data[] = { 0x01, 0x02, 0x03, 0x00, 0xFF };
+    int size = sizeof(data);
+
+    bool saved = SaveFileData(filename, data, size);
+    TEST_ASSERT_TRUE(saved);
+
+    int loaded_size = 0;
+    unsigned char* loaded_data = LoadFileData(filename, &loaded_size);
+    TEST_ASSERT_NOT_NULL(loaded_data);
+    TEST_ASSERT_EQUAL_INT(size, loaded_size);
+    TEST_ASSERT_EQUAL_MEMORY(data, loaded_data, size);
+
+    UnloadFileData(loaded_data);
+    remove(filename);
+}
+
+static void test_load_file_data_invalid(void)
+{
+    int loaded_size = -1;
+    unsigned char* loaded_data = LoadFileData("nonexistent_file_xyz123.bin", &loaded_size);
+    TEST_ASSERT_NULL(loaded_data);
+    TEST_ASSERT_EQUAL_INT(0, loaded_size);
+}
+
+static void test_save_file_data_invalid(void)
+{
+    bool saved = SaveFileData(NULL, "data", 4);
+    TEST_ASSERT_FALSE(saved);
+}
+
+static void test_file_text_save_load(void)
+{
+    const char* filename = "test_text.txt";
+    const char* text = "Hello, Raylib Shims!\nThis is a test.";
+
+    bool saved = SaveFileText(filename, text);
+    TEST_ASSERT_TRUE(saved);
+
+    char* loaded_text = LoadFileText(filename);
+    TEST_ASSERT_NOT_NULL(loaded_text);
+    TEST_ASSERT_EQUAL_STRING(text, loaded_text);
+
+    UnloadFileText(loaded_text);
+    remove(filename);
+}
+
+static void test_load_file_text_invalid(void)
+{
+    char* loaded_text = LoadFileText("nonexistent_file_xyz123.txt");
+    TEST_ASSERT_NULL(loaded_text);
+}
+
+static void test_save_file_text_invalid(void)
+{
+    bool saved = SaveFileText(NULL, "text");
+    TEST_ASSERT_FALSE(saved);
+}
+
+static void test_tracelog(void)
+{
+    /* Just verify it doesn't crash. Since we can't easily capture stdout in a portable way
+       without more code, simply calling it exercises the va_list and printf logic. */
+    TraceLog(3, "Test log message %d", 123);
+}
+
+void run_test_raylib_shims(void)
+{
+    RUN_TEST(test_mem_alloc_free);
+    RUN_TEST(test_file_data_save_load);
+    RUN_TEST(test_load_file_data_invalid);
+    RUN_TEST(test_save_file_data_invalid);
+    RUN_TEST(test_file_text_save_load);
+    RUN_TEST(test_load_file_text_invalid);
+    RUN_TEST(test_save_file_text_invalid);
+    RUN_TEST(test_tracelog);
+}


### PR DESCRIPTION
🎯 **What:** Missing tests for the Raylib compatibility shims (`src/raylib_shims.c`).
📊 **Coverage:** Added tests for memory allocation (`MemAlloc`, `MemRealloc`, `MemFree`), file I/O operations both binary (`SaveFileData`, `LoadFileData`, `UnloadFileData`) and text (`SaveFileText`, `LoadFileText`, `UnloadFileText`) including invalid inputs, and a basic test for `TraceLog`.
✨ **Result:** Improved test coverage, adding safety nets for compatibility shim functionality. Tests are fully integrated into the Unity test runner.

---
*PR created automatically by Jules for task [1528941387281874467](https://jules.google.com/task/1528941387281874467) started by @mendsec*