### PR TITLE
🧹 Remove dead code: teardown_state

### DIFF
--- a/src/app.h
+++ b/src/app.h
@@ -1,6 +1,8 @@
 #ifndef APP_H
 #define APP_H
 
+#include <stddef.h>
+
 /* app.h não depende de headers do Windows; evitar conflitos com Raylib */
 
 typedef struct {

--- a/src/parallel_scan.c
+++ b/src/parallel_scan.c
@@ -76,28 +76,6 @@ static DWORD WINAPI worker_proc(LPVOID lpParam)
     return 0;
 }
 
-/* ---- Safe teardown of previous state (if initialized) ---- */
-static void teardown_state(void)
-{
-    if (g_state.results_lock_initialized) {
-        device_list_clear(&g_state.results);
-        DeleteCriticalSection(&g_state.results_lock);
-        g_state.results_lock_initialized = 0;
-    }
-    if (g_state.state_lock_initialized) {
-        DeleteCriticalSection(&g_state.state_lock);
-        g_state.state_lock_initialized = 0;
-    }
-    /* Close any leftover thread handles */
-    for (int i = 0; i < g_state.num_threads; ++i) {
-        if (g_state.threads[i]) {
-            CloseHandle(g_state.threads[i]);
-            g_state.threads[i] = NULL;
-        }
-    }
-    g_state.num_threads = 0;
-}
-
 /* ---- Public API ---- */
 
 int parallel_scan_start(unsigned long start_ip_uint,


### PR DESCRIPTION
🎯 **What:** Removed the unused static function `teardown_state` in `src/parallel_scan.c`. Added `<stddef.h>` inclusion to `src/app.h`.
💡 **Why:** `teardown_state` was not referenced anywhere in its translation unit, making it dead code. Removing it improves codebase clarity and maintainability. Added `stddef.h` to fix a compiler error where `size_t` was missing, ensuring the test suite can be compiled properly.
✅ **Verification:** Verified by compiling the tests and running them, resulting in `33 Tests 0 Failures 0 Ignored OK`. Cross-compiled with `x86_64-w64-mingw32-gcc` and tested using `wine` since it relies on Windows networking functions.
✨ **Result:** A cleaner codebase with dead code removed, retaining all existing functionality. Test suite compilation is also fixed.

---
*PR created automatically by Jules for task [17442960498824710147](https://jules.google.com/task/17442960498824710147) started by @mendsec*