### PR TITLE
🧹 [Code Health] Remove dead `gui_log_snapshot` code from `src/main_raygui.c`

### DIFF
--- a/src/main_raygui.c
+++ b/src/main_raygui.c
@@ -91,17 +91,6 @@ static void gui_log_clear(void) {
     LeaveCriticalSection(&g_log_cs);
 }
 
-static void gui_log_snapshot(char out[][160], int* count, int max_lines) {
-    if (!out || !count || !g_log_cs_initialized) return;
-    EnterCriticalSection(&g_log_cs);
-    int n = g_log_count < 256 ? g_log_count : 256;
-    if (n > max_lines) n = max_lines;
-    for (int i = 0; i < n; ++i)
-        safe_strcpy(out[i], 160, g_log_lines[i]);
-    *count = n;
-    LeaveCriticalSection(&g_log_cs);
-}
-
 /* --- Admin privilege check --- */
 static bool check_is_admin(void) {
     BOOL isAdmin = FALSE;


### PR DESCRIPTION
🎯 **What:** Removed the uninvoked `gui_log_snapshot` function from `src/main_raygui.c`.
💡 **Why:** This improves the maintainability and readability of the codebase by eliminating dead code.
✅ **Verification:** Ensured using grep that the `gui_log_snapshot` function has been removed from `src/main_raygui.c` and is not referenced elsewhere. Code review verified that this is a safe cleanup with no regressions.
✨ **Result:** A cleaner codebase free of unused static internal functions.

---
*PR created automatically by Jules for task [9933458019318505264](https://jules.google.com/task/9933458019318505264) started by @mendsec*