### PR TITLE
🧪 Add unit test for scan_config_init

### DIFF
--- a/build_tests.ps1
+++ b/build_tests.ps1
@@ -7,7 +7,7 @@ $ErrorActionPreference = "Stop"
 # Ensure bin/ exists
 New-Item -ItemType Directory -Force -Path "bin" | Out-Null
 
-$buildCmd = 'clang-cl /nologo /W3 /TC /D _CRT_SECURE_NO_WARNINGS /D WIN32_LEAN_AND_MEAN /I src /I tests/unity tests/test_main.c tests/test_utils.c tests/test_list.c tests/test_parse_range.c tests/test_export.c tests/unity/unity.c src/utils.c src/list.c src/range_parser.c src/export.c /Fe"bin/catnet_tests.exe" /link Ws2_32.lib'
+$buildCmd = 'clang-cl /nologo /W3 /TC /D _CRT_SECURE_NO_WARNINGS /D WIN32_LEAN_AND_MEAN /I src /I tests/unity tests/test_main.c tests/test_utils.c tests/test_list.c tests/test_parse_range.c tests/test_export.c tests/test_scan.c tests/unity/unity.c src/utils.c src/list.c src/range_parser.c src/export.c src/scan.c src/net.c /Fe"bin/catnet_tests.exe" /link Ws2_32.lib Iphlpapi.lib'
 
 # Determine which compiler is available in PATH
 $cc = $null

--- a/src/app.h
+++ b/src/app.h
@@ -1,6 +1,8 @@
 #ifndef APP_H
 #define APP_H
 
+#include <stddef.h>
+
 /* app.h não depende de headers do Windows; evitar conflitos com Raylib */
 
 typedef struct {

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -6,6 +6,7 @@ void run_test_utils(void);
 void run_test_list(void);
 void run_test_parse_range(void);
 void run_test_export(void);
+void run_test_scan(void);
 
 /* Global setUp/tearDown required by Unity when compiling multiple test files */
 void setUp(void) {}
@@ -18,5 +19,6 @@ int main(void)
     run_test_list();
     run_test_parse_range();
     run_test_export();
+    run_test_scan();
     return UNITY_END();
 }

--- a/tests/test_scan.c
+++ b/tests/test_scan.c
@@ -1,0 +1,24 @@
+/* tests/test_scan.c — Unit tests for src/scan.c
+ */
+#include "unity/unity.h"
+#include "../src/scan.h"
+
+static void test_scan_config_init(void)
+{
+    ScanConfig cfg;
+    scan_config_init(&cfg);
+
+    TEST_ASSERT_EQUAL_INT(6, cfg.default_ports_count);
+    TEST_ASSERT_EQUAL_INT(22, cfg.default_ports[0]);
+    TEST_ASSERT_EQUAL_INT(80, cfg.default_ports[1]);
+    TEST_ASSERT_EQUAL_INT(443, cfg.default_ports[2]);
+    TEST_ASSERT_EQUAL_INT(139, cfg.default_ports[3]);
+    TEST_ASSERT_EQUAL_INT(445, cfg.default_ports[4]);
+    TEST_ASSERT_EQUAL_INT(3389, cfg.default_ports[5]);
+    TEST_ASSERT_EQUAL_INT(500, cfg.port_timeout_ms);
+}
+
+void run_test_scan(void)
+{
+    RUN_TEST(test_scan_config_init);
+}


### PR DESCRIPTION
🎯 **What:** `src/scan.c` had missing tests, particularly for its default configuration logic in `scan_config_init`.

📊 **Coverage:** A new Unity test suite `tests/test_scan.c` has been added. The test asserts that `scan_config_init` correctly assigns its configuration parameters (default ports and default timeout). The test was properly linked to the test runner via `tests/test_main.c` and integrated into the `build_tests.ps1` PowerShell script.

✨ **Result:** Test coverage improved by verifying that network scan configurations start in their proper initial state without dependencies. Also patched `src/app.h` slightly to correctly include `<stddef.h>` for `size_t`.

---
*PR created automatically by Jules for task [9714324824244615377](https://jules.google.com/task/9714324824244615377) started by @mendsec*