### PR TITLE
🔒 Fix CSV Injection Vulnerability in Export Results

### DIFF
--- a/src/export.c
+++ b/src/export.c
@@ -1,16 +1,54 @@
 #include "export.h"
 #include <stdio.h>
 
+static void csv_write_field(FILE* f, const char* s)
+{
+    if (!s) s = "";
+
+    // Check if we need to mitigate CSV formula injection
+    int mitigate_injection = 0;
+    if (s[0] == '=' || s[0] == '+' || s[0] == '-' || s[0] == '@' || s[0] == '\t' || s[0] == '\r') {
+        mitigate_injection = 1;
+    }
+
+    fputc('"', f);
+    if (mitigate_injection) {
+        fputc('\'', f);
+    }
+
+    for (; *s; ++s) {
+        if (*s == '"') {
+            fputs("\"\"", f);
+        } else {
+            fputc(*s, f);
+        }
+    }
+    fputc('"', f);
+}
+
 int export_results_to_file(const char* path, const DeviceList* list) {
     FILE* f = fopen(path, "w");
     if (!f) return 0;
     fprintf(f, "IP;Hostname;MAC;Status;Ports\n");
     for (size_t i=0; i<list->count; ++i) {
         const DeviceInfo* di = &list->items[i];
-        fprintf(f, "%s;%s;%s;%s;", di->ip, di->hostname[0]?di->hostname:"", di->mac[0]?di->mac:"", di->is_alive?"UP":"DOWN");
+
+        csv_write_field(f, di->ip);
+        fputc(';', f);
+        csv_write_field(f, di->hostname[0] ? di->hostname : "");
+        fputc(';', f);
+        csv_write_field(f, di->mac[0] ? di->mac : "");
+        fputc(';', f);
+
+        fprintf(f, "%s;", di->is_alive ? "UP" : "DOWN");
+
+        // Ports field
+        fputc('"', f);
         for (int p=0; p<di->open_ports_count; ++p) {
             fprintf(f, "%d%s", di->open_ports[p], (p<di->open_ports_count-1?",":""));
         }
+        fputc('"', f);
+
         fprintf(f, "\n");
     }
     fclose(f);

--- a/tests/test_export.c
+++ b/tests/test_export.c
@@ -159,7 +159,52 @@ static void test_json_hostname_with_newline(void)
 }
 
 /* -----------------------------------------------------------------------
- * Test 5: export_results_to_file with invalid path -> returns 0
+ * Test 5: export_results_to_file with CSV injection payloads
+ * --------------------------------------------------------------------- */
+static void test_csv_export_mitigation(void)
+{
+    const char* path = "tmp_test_export_mitigation.csv";
+    DeviceList list;
+
+    // Create a device list with potentially malicious/breaking hostnames
+    device_list_init(&list);
+
+    DeviceInfo di1;
+    memset(&di1, 0, sizeof(di1));
+    strncpy(di1.ip, "10.0.0.1", sizeof(di1.ip) - 1);
+    strncpy(di1.hostname, "=cmd|' /C calc'!A0", sizeof(di1.hostname) - 1);
+    di1.is_alive = 1;
+    device_list_push(&list, &di1);
+
+    DeviceInfo di2;
+    memset(&di2, 0, sizeof(di2));
+    strncpy(di2.ip, "10.0.0.2", sizeof(di2.ip) - 1);
+    strncpy(di2.hostname, "normal;break\nnewline", sizeof(di2.hostname) - 1);
+    di2.is_alive = 1;
+    device_list_push(&list, &di2);
+
+    int ret = export_results_to_file(path, &list);
+    TEST_ASSERT_EQUAL_INT(1, ret);
+
+    char buf[1024];
+    TEST_ASSERT_EQUAL_INT(1, read_file_content(path, buf, sizeof(buf)));
+
+    // Check if the formula injection is mitigated (starts with ' inside the quotes)
+    TEST_ASSERT_NOT_NULL(strstr(buf, "\"'=cmd|' /C calc'!A0\""));
+
+    // Check if the semicolon and newline are properly enclosed in quotes
+    TEST_ASSERT_NOT_NULL(strstr(buf, "\"normal;break\nnewline\""));
+
+    // Check if IPs are quoted
+    TEST_ASSERT_NOT_NULL(strstr(buf, "\"10.0.0.1\""));
+    TEST_ASSERT_NOT_NULL(strstr(buf, "\"10.0.0.2\""));
+
+    device_list_clear(&list);
+    remove(path);
+}
+
+/* -----------------------------------------------------------------------
+ * Test 6: export_results_to_file with invalid path -> returns 0
  * --------------------------------------------------------------------- */
 static void test_csv_invalid_path_returns_zero(void)
 {
@@ -196,6 +241,7 @@ void run_test_export(void)
     RUN_TEST(test_json_single_device);
     RUN_TEST(test_json_hostname_with_quote);
     RUN_TEST(test_json_hostname_with_newline);
+    RUN_TEST(test_csv_export_mitigation);
     RUN_TEST(test_csv_invalid_path_returns_zero);
     RUN_TEST(test_json_invalid_path_returns_zero);
 }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The `export_results_to_file` function suffered from a CSV Injection (Formula Injection) vulnerability. The application exports network device details such as hostnames directly into a delimited file without escaping or sanitization. If a hostname contained commas/semicolons, it would break the file structure. Worse, if a malicious hostname contained formula injection vectors (`=`, `+`, `-`, `@`), a user opening the exported CSV in applications like Microsoft Excel or LibreOffice Calc could unwittingly execute arbitrary code or formulas on their system.

⚠️ **Risk:** The potential impact if left unfixed
High client-side risk. If a malicious user controls the DNS record or hostname resolution of a local device, they can force the `CatNet Scanner` to export an insidious string. When the user opens the exported CSV file with Excel, the formula can result in arbitrary code execution (DDE attacks) or data exfiltration. Furthermore, non-malicious devices with semicolons in their hostnames would cause malformed CSVs.

🛡️ **Solution:** How the fix addresses the vulnerability
A new `csv_write_field` helper function was added to properly structure strings for CSV output. It safely encodes output in double quotes and escapes existing double quotes inside strings. To prevent CSV Injection, if a string starts with `=, +, -, @, \t,` or `\r`, the function prepends a single quotation mark (`'`), forcing spreadsheet programs to interpret the malicious payload purely as plain text. This completely closes the DDE/CSV injection vector while maintaining correct data formatting. Additional unit tests were added to ensure robustness against payloads and delimiters.

---
*PR created automatically by Jules for task [3554120037950327794](https://jules.google.com/task/3554120037950327794) started by @mendsec*