### PR TITLE
🎨 Palette: Add tooltips to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Raygui Icon-Only Button Accessibility]
+**Learning:** Immediate-mode GUIs like Raygui often don't have built-in accessible properties like `aria-label` or automatic tooltips for icon-only buttons. To provide accessibility for icon-only buttons, we need to explicitly enable tooltips globally with `GuiEnableTooltip()` and dynamically set the tooltip text using `GuiSetTooltip("Context")` right before rendering the button, and reset it using `GuiSetTooltip(NULL)` immediately after.
+**Action:** When working with Raygui, always enable tooltips on app initialization and ensure every icon-only or ambiguous `GuiButton` is wrapped with `GuiSetTooltip` to provide proper context and accessibility for users.

--- a/src/main_raygui.c
+++ b/src/main_raygui.c
@@ -176,6 +176,7 @@ const int splitBarH = padding;  // Vertical gap equals global padding
     DeviceList results; device_list_init(&results);
     ScanConfig cfg; scan_config_init(&cfg);
     bool isScanning = false;
+    GuiEnableTooltip();
     apply_theme(true);
     // Increase global font size for readability
     GuiSetStyle(DEFAULT, TEXT_SIZE, 18);
@@ -262,11 +263,15 @@ const int splitBarH = padding;  // Vertical gap equals global padding
         float rightX = (float)(screenWidth - padding*3); // move a bit left from the edge
         float btnW = 34, btnH = 28;
         rightX -= btnW;
+        GuiSetTooltip("Help");
         if (GuiButton((Rectangle){ rightX, padding, btnW, btnH }, NULL)) { gui_log_push("Help clicked", NULL); }
+        GuiSetTooltip(NULL);
         GuiDrawIcon(ICON_HELP, (int)(rightX + btnW/2 - 8), (int)(padding + btnH/2 - 8), 1, GetColor(GuiGetStyle(DEFAULT, TEXT_COLOR_NORMAL)));
         rightX -= itemSpacing;
         rightX -= btnW;
+        GuiSetTooltip("Settings");
         if (GuiButton((Rectangle){ rightX, padding, btnW, btnH }, NULL)) { gui_log_push("Settings clicked", NULL); }
+        GuiSetTooltip(NULL);
         GuiDrawIcon(ICON_GEAR, (int)(rightX + btnW/2 - 8), (int)(padding + btnH/2 - 8), 1, GetColor(GuiGetStyle(DEFAULT, TEXT_COLOR_NORMAL)));
         
         // ---- 2. Scan Configuration Panel ----


### PR DESCRIPTION
- 💡 What: Enabled global tooltips in Raygui and added tooltips to the icon-only 'Help' and 'Settings' buttons.
- 🎯 Why: Icon-only buttons without text labels are confusing for users and inaccessible, as their purpose isn't explicitly clear without prior context.
- 📸 Before/After: Before, hovering over Help/Settings icons showed nothing. Now, hovering displays a tooltip explaining the action.
- ♿ Accessibility: Improves accessibility by providing contextual descriptions for icon-only interactive elements.

---
*PR created automatically by Jules for task [16475798966446143100](https://jules.google.com/task/16475798966446143100) started by @mendsec*