### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSV Injection in Export

### DIFF
--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -53,6 +53,16 @@ func ExportXML(devices []scanner.DeviceInfo) ([]byte, error) {
 	return data, nil
 }
 
+func sanitizeCSVField(field string) string {
+	if len(field) > 0 {
+		firstChar := field[0]
+		if firstChar == '=' || firstChar == '+' || firstChar == '-' || firstChar == '@' || firstChar == '\t' || firstChar == '\r' {
+			return "'" + field
+		}
+	}
+	return field
+}
+
 func ExportCSV(devices []scanner.DeviceInfo) ([]byte, error) {
 	var buf bytes.Buffer
 	writer := csv.NewWriter(&buf)
@@ -73,7 +83,9 @@ func ExportCSV(devices []scanner.DeviceInfo) ([]byte, error) {
 		}
 		ports := strings.Join(strPorts, ";")
 
-		err = writer.Write([]string{d.IP, d.Hostname, d.MAC, status, ports})
+		hostname := sanitizeCSVField(d.Hostname)
+
+		err = writer.Write([]string{d.IP, hostname, d.MAC, status, ports})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -10,6 +10,8 @@ func TestExportCSV(t *testing.T) {
 	devices := []scanner.DeviceInfo{
 		{IP: "192.168.1.1", Hostname: "router", MAC: "AA-BB-CC-DD-EE-FF", IsAlive: true, OpenPorts: []int{80, 443}},
 		{IP: "192.168.1.2", Hostname: "server,backup", MAC: "11-22-33-44-55-66", IsAlive: true, OpenPorts: []int{22}},
+		{IP: "192.168.1.3", Hostname: "=cmd|' /C calc'!A0", MAC: "00-11-22-33-44-55", IsAlive: true, OpenPorts: []int{8080}},
+		{IP: "192.168.1.4", Hostname: "+1+1", MAC: "00-11-22-33-44-56", IsAlive: true, OpenPorts: []int{8081}},
 	}
 
 	out, err := ExportCSV(devices)
@@ -25,6 +27,14 @@ func TestExportCSV(t *testing.T) {
 	// Server has a comma in hostname, it should be escaped properly by encoding/csv
 	if !strings.Contains(str, "\"server,backup\"") {
 		t.Errorf("Hostname with comma not properly escaped in CSV: %s", str)
+	}
+
+	// CSV Injection tests
+	if !strings.Contains(str, "192.168.1.3,'=cmd|' /C calc'!A0") {
+		t.Errorf("Hostname starting with '=' not properly sanitized against CSV injection: %s", str)
+	}
+	if !strings.Contains(str, "192.168.1.4,'+1+1") {
+		t.Errorf("Hostname starting with '+' not properly sanitized against CSV injection: %s", str)
 	}
 }
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** CSV / Formula Injection. The application exports network scan results to CSV. The `Hostname` field, resolved via Reverse DNS, was not sanitized before export. Malicious actors on the local network could theoretically spoof DNS entries to inject spreadsheet formulas into the CSV output.
🎯 **Impact:** If a victim exports the results to CSV and opens the file in a spreadsheet program (e.g., Excel), the injected formulas could execute, potentially leading to remote code execution (RCE) on the victim's machine.
🔧 **Fix:** Implemented `sanitizeCSVField` in `pkg/exporter/exporter.go` to prefix any field starting with a formula character (`=`, `+`, `-`, `@`, `\t`, `\r`) with a single quote (`'`). This neutralizes the formula, treating it as raw text. Tests were added to ensure proper coverage.
✅ **Verification:** Verified by unit tests in `pkg/exporter/exporter_test.go` and manually testing the CSV export payload logic.

Additionally, added a journal entry to `.jules/sentinel.md` documenting this finding.

---
*PR created automatically by Jules for task [8120905483617133703](https://jules.google.com/task/8120905483617133703) started by @mendsec*