### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Denial of Service in CIDR parsing

### DIFF
--- a/pkg/scanner/utils.go
+++ b/pkg/scanner/utils.go
@@ -36,9 +36,20 @@ func parseCIDR(cidr string) ([]string, error) {
 		return nil, err
 	}
 
+	ones, bits := ipnet.Mask.Size()
+	// Prevent DoS: if the subnet is too large (more than /16 for IPv4 or equivalent), return an error
+	// A /16 network has 65536 addresses, which is our max limit.
+	if bits-ones > 16 {
+		return nil, fmt.Errorf("CIDR range too large (max 65536)")
+	}
+
 	var ips []string
 	for ip := ip.Mask(ipnet.Mask); ipnet.Contains(ip); inc(ip) {
 		ips = append(ips, ip.String())
+		// Backup safeguard
+		if len(ips) > 65536 {
+			return nil, fmt.Errorf("CIDR range too large (max 65536)")
+		}
 	}
 
 	// Remove network address and broadcast address for standard IPv4 subnets

--- a/pkg/scanner/utils_test.go
+++ b/pkg/scanner/utils_test.go
@@ -19,6 +19,7 @@ func TestParseRange(t *testing.T) {
 		{"Empty input", " ", 0, true},
 		{"Reversed range", "192.168.1.10-192.168.1.1", 0, true},
 		{"Range too large", "10.0.0.1-10.2.0.0", 0, true}, // > 65536 is error
+		{"CIDR too large", "10.0.0.0/8", 0, true}, // > 65536 is error
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: Denial of Service (DoS) via memory exhaustion in `pkg/scanner/utils.go` during the parsing of very large CIDR blocks (e.g., `10.0.0.0/8`). The application attempted to allocate millions of IP strings into a single slice, leading to an Out-Of-Memory (OOM) crash.
🎯 **Impact**: An attacker or an unaware user could input an excessively large CIDR block, crashing the application completely.
🔧 **Fix**: Added validation to `parseCIDR` limiting the number of allocated addresses to a maximum of 65,536 (the equivalent of a `/16` IPv4 subnet). Added both bit size verification and in-loop defense-in-depth safety limits. 
✅ **Verification**: Run `go test ./pkg/...` and ensure all tests are successfully executed, specifically checking `TestParseRange` which now explicitly tests this new constraint using `10.0.0.0/8`.

---
*PR created automatically by Jules for task [16820587589256882173](https://jules.google.com/task/16820587589256882173) started by @mendsec*