### PR TITLE
🎨 Palette: Improve button disabled states and add focus indicators

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -173,13 +173,13 @@ function App() {
               <span id="ip-error-msg" role="alert" style={{ position: 'absolute', top: '100%', left: '0', color: 'var(--status-dead)', fontSize: '11px', marginTop: '2px' }}>Invalid format</span>
             )}
           </div>
-          <button className="cyber-btn" onClick={handleScan} disabled={isScanning || !isValidIpRange(ipRange)}>
+          <button className="cyber-btn" onClick={handleScan} disabled={isScanning || !isValidIpRange(ipRange)} title={isScanning ? "Scanning in progress" : !isValidIpRange(ipRange) ? "Enter a valid IP range to start scanning" : "Start scanning"}>
             <Play size={18} /> {isScanning ? 'Scanning...' : 'Start'}
           </button>
-          <button className="cyber-btn danger" onClick={handleStop} disabled={!isScanning}>
+          <button className="cyber-btn danger" onClick={handleStop} disabled={!isScanning} title={!isScanning ? "No scan in progress" : "Stop scanning"}>
             <Square size={18} /> Stop
           </button>
-          <button className="cyber-btn" onClick={handleExport} disabled={isScanning || devices.length === 0} style={{ borderColor: 'var(--text-muted)', color: 'var(--text-muted)' }}>
+          <button className="cyber-btn" onClick={handleExport} disabled={isScanning || devices.length === 0} style={{ borderColor: 'var(--text-muted)', color: 'var(--text-muted)' }} title={isScanning ? "Wait for scan to finish" : devices.length === 0 ? "No devices found to export" : "Export results"}>
             <Download size={18} /> Export
           </button>
         </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -134,10 +134,24 @@ body {
   gap: 8px;
 }
 
-.cyber-btn:hover {
+.cyber-btn:not(:disabled):hover {
   background: var(--text-highlight);
   color: var(--bg-color);
   box-shadow: 0 0 15px rgba(102, 252, 241, 0.6);
+}
+
+.cyber-btn:disabled,
+.icon-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: auto; /* Required to show tooltips on disabled buttons */
+}
+
+.cyber-btn:focus-visible,
+.icon-btn:focus-visible,
+.cyber-input:focus-visible {
+  outline: 2px solid var(--text-highlight);
+  outline-offset: 2px;
 }
 
 .icon-btn {
@@ -157,7 +171,7 @@ body {
   transition: all 0.3s;
 }
 
-.icon-btn:hover {
+.icon-btn:not(:disabled):hover {
   color: var(--text-highlight);
   border-color: var(--text-highlight);
 }
@@ -167,7 +181,7 @@ body {
   border-color: var(--accent-danger);
 }
 
-.cyber-btn.danger:hover {
+.cyber-btn.danger:not(:disabled):hover {
   background: var(--accent-danger);
   color: #fff;
   box-shadow: 0 0 15px rgba(255, 0, 85, 0.6);


### PR DESCRIPTION
💡 What: Added informative `title` tooltips to the primary action buttons (`Start`, `Stop`, `Export`) to explain why they are disabled. Also added `:disabled` visual states and `:focus-visible` rings.
🎯 Why: Disabled buttons without context are a common UX anti-pattern. Tooltips explain *why* an action cannot be performed right now. The `:focus-visible` states drastically improve keyboard accessibility.
♿ Accessibility: Better focus indicators for keyboard navigation.

Additionally recorded UX learnings into `.jules/palette.md` noting the interplay between `pointer-events: auto` and native browser `title` tooltips on disabled buttons.

---
*PR created automatically by Jules for task [2798111868768376245](https://jules.google.com/task/2798111868768376245) started by @mendsec*