### PR TITLE
Merge develop into main – fix multi-repo CI workflows and stabilize Ubuntu 24.04 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,13 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.26.x'
           
       - name: Backend test
         working-directory: catnet-scanner
-        run: go test ./...
+        env:
+          CGO_ENABLED: 1
+        run: go test -race -v ./...
 
   frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,39 +1,57 @@
-﻿name: CI
+name: CI
 
 on:
   push:
+    branches: [ "main", "develop" ]
   pull_request:
 
 jobs:
   backend:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout catnet-scanner
         uses: actions/checkout@v4
+        with:
+          path: catnet-scanner
+
+      - name: Checkout catnet-core
+        uses: actions/checkout@v4
+        with:
+          repository: mendsec/catnet-core
+          path: catnet-core
 
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
-
+          go-version: '1.22'
+          
       - name: Backend test
+        working-directory: catnet-scanner
         run: go test ./...
 
   frontend:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout catnet-scanner
         uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          path: catnet-scanner
+
+      - name: Checkout catnet-core
+        uses: actions/checkout@v4
+        with:
+          repository: mendsec/catnet-core
+          path: catnet-core
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
 
       - name: Install dependencies
-        working-directory: frontend
-        run: npm ci
+        working-directory: catnet-scanner/frontend
+        run: bun install
 
       - name: Build frontend
-        working-directory: frontend
-        run: npm run build
+        working-directory: catnet-scanner/frontend
+        run: bun run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
       - name: Install Linux Dependencies
         run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
 
+      - name: Mock frontend dist
+        working-directory: catnet-scanner
+        run: mkdir -p frontend/dist; echo "mock" > frontend/dist/index.html
+
       - name: Backend test
         working-directory: catnet-scanner
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           go-version: '1.26.x'
           
       - name: Install Linux Dependencies
-        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
 
       - name: Mock frontend dist
         working-directory: catnet-scanner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           go-version: '1.26.x'
           
+      - name: Install Linux Dependencies
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
+
       - name: Backend test
         working-directory: catnet-scanner
         env:

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -12,19 +12,29 @@ jobs:
   govulncheck:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout catnet-scanner
         uses: actions/checkout@v6
+        with:
+          path: catnet-scanner
+
+      - name: Checkout catnet-core
+        uses: actions/checkout@v6
+        with:
+          repository: mendsec/catnet-core
+          path: catnet-core
       
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libwebkit2gtk-4.0-dev || true
       
       - name: Mock frontend dist
         shell: bash
+        working-directory: catnet-scanner
         run: mkdir -p frontend/dist; echo "mock" > frontend/dist/index.html
       
       - name: Run govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: '1.25.x'
+          go-version-input: '1.26.x'
           go-package: ./...
+          work-dir: ./catnet-scanner
           repo-checkout: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Install Linux Dependencies
       if: runner.os == 'Linux'
-      run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
+      run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
 
     - name: Build Wails App
       working-directory: catnet-scanner

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,21 @@ jobs:
     runs-on: ${{ matrix.os }}
     
     steps:
-    - uses: actions/checkout@v6
+    - name: Checkout catnet-scanner
+      uses: actions/checkout@v6
+      with:
+        path: catnet-scanner
+
+    - name: Checkout catnet-core
+      uses: actions/checkout@v6
+      with:
+        repository: mendsec/catnet-core
+        path: catnet-core
 
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.x'
+        go-version: '1.26.x'
 
     - name: Set up Bun
       uses: oven-sh/setup-bun@v2
@@ -40,9 +49,11 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
 
     - name: Build Wails App
+      working-directory: catnet-scanner
       run: wails build -platform ${{ matrix.platform }}
 
     - name: Rename build
+      working-directory: catnet-scanner
       run: |
         if [ "$RUNNER_OS" == "Windows" ]; then
           mv build/bin/*.exe build/bin/${{ matrix.name }}
@@ -55,7 +66,7 @@ jobs:
       uses: actions/upload-artifact@v7
       with:
         name: ${{ matrix.name }}
-        path: build/bin/${{ matrix.name }}
+        path: catnet-scanner/build/bin/${{ matrix.name }}
 
   release:
     needs: build
@@ -63,8 +74,10 @@ jobs:
     permissions:
       contents: write
     steps:
-    - name: Checkout code
+    - name: Checkout catnet-scanner
       uses: actions/checkout@v6
+      with:
+        path: catnet-scanner
 
     - name: Download all artifacts
       uses: actions/download-artifact@v8
@@ -73,6 +86,7 @@ jobs:
 
     - name: Extract Release Notes
       id: extract-notes
+      working-directory: catnet-scanner
       run: |
         VERSION=${GITHUB_REF#refs/tags/}
         VERSION_NO_V=${VERSION#v}
@@ -82,4 +96,4 @@ jobs:
       uses: softprops/action-gh-release@v1
       with:
         files: artifacts/**/*
-        body_path: RELEASE_NOTES.md
+        body_path: catnet-scanner/RELEASE_NOTES.md

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -10,31 +10,48 @@ jobs:
   snyk-go:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout catnet-scanner
+        uses: actions/checkout@v6
+        with:
+          path: catnet-scanner
+      - name: Checkout catnet-core
+        uses: actions/checkout@v6
+        with:
+          repository: mendsec/catnet-core
+          path: catnet-core
       - name: Mock frontend dist
+        working-directory: catnet-scanner
         run: mkdir -p frontend/dist; echo "mock" > frontend/dist/index.html
       - name: Run Snyk to check Go vulnerabilities
         uses: snyk/actions/golang@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --file=go.mod
+          args: --file=catnet-scanner/go.mod
 
   snyk-frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout catnet-scanner
+        uses: actions/checkout@v6
+        with:
+          path: catnet-scanner
+      - name: Checkout catnet-core
+        uses: actions/checkout@v6
+        with:
+          repository: mendsec/catnet-core
+          path: catnet-core
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - name: Install dependencies
-        working-directory: frontend
+        working-directory: catnet-scanner/frontend
         run: bun install
       - name: Setup Snyk
         uses: snyk/actions/setup@master
       - name: Run Snyk to check Bun vulnerabilities
-        working-directory: frontend
+        working-directory: catnet-scanner/frontend
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: snyk test --file=package.json

--- a/docs/ci_troubleshooting/README.md
+++ b/docs/ci_troubleshooting/README.md
@@ -95,3 +95,17 @@ Durante a mudança arquitetural para "The CatNet Ecosystem", o repositório adot
 - **Checkouts Multi-repo:** Alteramos `release.yml`, `govulncheck.yml` e `snyk.yml` para realizar o checkout de ambos os repositórios (`catnet-scanner` e `catnet-core`) usando a flag `path:`, espelhando a configuração correta do `ci.yml`.
 - **Redirecionamento de Diretório (Working Directory):** Adicionamos as propriedades de `working-directory: catnet-scanner` (ou o prefixo `catnet-scanner/` em campos específicos de Custom Actions como `work-dir` e `args: --file=...`) aos passos de compilação, Snyk, Govulncheck, e extração de release para que operem sob o diretório local onde o projeto foi clonado.
 - **Normalização do Go:** Atualizamos `go-version` e `go-version-input` de todos os actions para a nova baseline (`1.26.x`), resolvendo qualquer downgrade assíncrono ocorrido nos merges entre `main` e `develop`.
+
+---
+
+### 7. PR #28 - Falhas Ocultas em CGO e Dependências Nativas no Ubuntu 24.04
+
+**Sintoma:** Após estabilizar os checkouts, o backend test continuou falhando na Action de CI, reclamando ora que `gcc` não estava disponível para a compilação paralela com a flag `-race`, ora com o pacote de WebKit resultando em `Exit code 100` (`Unable to locate package libwebkit2gtk-4.0-dev`).
+
+**Causa Raiz:** 
+1. **Runner `ubuntu-latest` (Noble Numbat):** O GitHub migrou os runners de `ubuntu-latest` para Ubuntu 24.04, o qual substituiu totalmente o pacote `libwebkit2gtk-4.0-dev` pela versão mais moderna `libwebkit2gtk-4.1-dev`. O comando estático com `-4.0-dev` quebrou imediatamente.
+2. **Dependência do Frontend Mock em Testes:** A flag `CGO_ENABLED: 1` obrigou o runner a cruzar dependências de C. Como usamos _Wails_, isso gerou dependência real no GTK. Além disso, o teste `go test` verificava a integridade de `//go:embed all:frontend/dist`. Como os testes rodam em paralelo ao `bun build`, o diretório frontend mock não existia nativamente no escopo do runner backend.
+
+**Solução Aplicada:**
+- Alteramos permanentemente nos workflows (`ci.yml` e `release.yml`) a dependência instalada para `libwebkit2gtk-4.1-dev`.
+- Injetamos o script de **Mock do Frontend** antes do step de teste (`mkdir -p frontend/dist; echo "mock" > frontend/dist/index.html`) para enganar a validação do `go:embed`.

--- a/docs/ci_troubleshooting/README.md
+++ b/docs/ci_troubleshooting/README.md
@@ -81,3 +81,17 @@ Como os PRs #25 e #26 também foram criados pelo Dependabot (para atualizar as a
 - Feito um commit vazio (`git commit --allow-empty`) a partir de uma conta mantenedora do projeto diretamente nas branches dos PRs.
 - Isso reiniciou o CI rodando sob o contexto de um membro mantenedor, permitindo que a Action consumisse o token corretamente.
 - *(Reforça a necessidade de adicionar o token aos "Dependabot Secrets" para evitar retrabalho futuro).*
+
+---
+
+### 6. PR #27 - Falha nos Workflows após Migração para Multi-Repo
+
+**Sintoma:** Os workflows `release.yml`, `govulncheck.yml` e `snyk.yml` começaram a falhar com erros de "module not found" (falha ao resolver a diretiva `replace` de `../catnet-core`) e/ou conflito de versão do Go (`go.mod requires go >= 1.26.3`).
+
+**Causa Raiz:** 
+Durante a mudança arquitetural para "The CatNet Ecosystem", o repositório adotou um padrão multi-repo (workspace) que inseriu a diretiva `replace github.com/mendsec/catnet-core => ../catnet-core` no `go.mod`. Na branch `develop`, o checkout duplo foi implementado em `ci.yml`, mas não foi propagado para os demais workflows. Consequentemente, esses actions executavam no diretório raiz sem clonar a dependência principal lado-a-lado. Além disso, as definições do `go-version` nestes workflows divergiram do novo baseline da aplicação.
+
+**Solução Aplicada:**
+- **Checkouts Multi-repo:** Alteramos `release.yml`, `govulncheck.yml` e `snyk.yml` para realizar o checkout de ambos os repositórios (`catnet-scanner` e `catnet-core`) usando a flag `path:`, espelhando a configuração correta do `ci.yml`.
+- **Redirecionamento de Diretório (Working Directory):** Adicionamos as propriedades de `working-directory: catnet-scanner` (ou o prefixo `catnet-scanner/` em campos específicos de Custom Actions como `work-dir` e `args: --file=...`) aos passos de compilação, Snyk, Govulncheck, e extração de release para que operem sob o diretório local onde o projeto foi clonado.
+- **Normalização do Go:** Atualizamos `go-version` e `go-version-input` de todos os actions para a nova baseline (`1.26.x`), resolvendo qualquer downgrade assíncrono ocorrido nos merges entre `main` e `develop`.


### PR DESCRIPTION
## Summary

This PR merges the `develop` branch into `main`, integrating critical CI/CD fixes for the multi-repo workspace setup and stabilizing builds on GitHub Actions' Ubuntu 24.04 runners.

Key changes:
- Normalize Go version across all workflows to `1.26.x`
- Add multi-repo checkout for `catnet-scanner` and `catnet-core` in `release.yml`, `govulncheck.yml`, and `snyk.yml`
- Add `working-directory: catnet-scanner` (and related path prefixes) for build, test, Snyk, and govulncheck steps
- Update Linux dependencies from `libwebkit2gtk-4.0-dev` to `libwebkit2gtk-4.1-dev` for Ubuntu 24.04
- Add Linux dependency installation for CGO testing and a frontend mock to satisfy `go:embed` validation
- Enable race detector in backend tests (`go test -race -v ./...`)
- Switch frontend from Node to Bun and update dependency install/build steps
- Update documentation with detailed troubleshooting for PRs #27 and #28 (multi-repo workflow failures and CGO/WebKit issues)

## Type of change

- [x] CI/Infra
- [x] Bug fix (workflow failures)
- [ ] Feature
- [ ] Refactor
- [x] Documentation

## Validation

- [x] Workflows updated to match multi-repo workspace structure
- [x] CI checks pass on `develop` (all 5 checks OK on latest commits)
- [x] Go version consistent across `ci.yml`, `release.yml`, `govulncheck.yml`, and `snyk.yml`
- [x] Documentation updated with root cause and solution for recent CI failures [page:13]