### PR TITLE
🎨 Palette: Update empty state to reflect scanning status

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-23 - Handle asynchronous state in empty components
+**Learning:** Tables or lists should provide clear visual feedback when an asynchronous operation (like network scanning) is active, otherwise the "empty state" message can mislead users into thinking the application is idle or stuck.
+**Action:** When creating empty states, check if there is an active loading or processing state, and display a specific "Loading..." or "Processing..." message instead of the default "Ready" or "No results" message.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -229,7 +229,7 @@ function App() {
             {devices.length === 0 && (
               <tr>
                 <td colSpan={5} style={{ textAlign: 'center', padding: '30px', color: 'var(--text-muted)' }}>
-                  Ready to scan. Awaiting input.
+                  {isScanning ? 'Scanning network...' : 'Ready to scan. Awaiting input.'}
                 </td>
               </tr>
             )}


### PR DESCRIPTION
💡 **What:**
Updated the empty state message in the results table to dynamically switch between "Ready to scan. Awaiting input." and "Scanning network..." based on the application's scanning state.

🎯 **Why:**
Previously, when the user initiated a scan, the table would briefly display "Ready to scan. Awaiting input." before results started streaming in. This could mislead users into thinking the scan had not started or had failed. The new state accurately reflects the asynchronous operation.

♿ **Accessibility:**
Provides clearer context for users relying on visual cues regarding the application's active background state.

---
*PR created automatically by Jules for task [2540471519602517613](https://jules.google.com/task/2540471519602517613) started by @mendsec*