### PR TITLE
🎨 Palette: Add keyboard accessibility to table sorting and scan input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Accessibility for Table Headers and Form Inputs
+**Learning:** Interactive table headers used for sorting must have explicit `role="button"`, `tabIndex={0}`, and `aria-sort` attributes to be fully accessible to keyboard and screen reader users. Furthermore, input fields handling main actions should naturally support submission via the Enter key without requiring a surrounding form element, provided keydown events are handled manually.
+**Action:** When making custom components interactive (like table headers or non-form inputs), always map the `onKeyDown` events (Enter/Space) and ensure proper ARIA roles and focus-visible styling are applied.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -168,6 +168,14 @@ function App() {
               className="cyber-input" 
               value={ipRange}
               onChange={e => setIpRange(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  if (!isScanning && isValidIpRange(ipRange)) {
+                    handleScan();
+                  }
+                }
+              }}
               disabled={isScanning}
               placeholder="IP Range / CIDR"
               aria-label="IP Range or CIDR"
@@ -208,10 +216,42 @@ function App() {
           <thead>
             <tr>
               <th>Status</th>
-              <th onClick={() => handleSort('hostname')}>Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('ip')}>IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('open_ports')}>Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('mac')}>MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}</th>
+              <th
+                role="button"
+                tabIndex={0}
+                aria-sort={sortCol === 'hostname' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+                onClick={() => handleSort('hostname')}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort('hostname'); } }}
+              >
+                Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                role="button"
+                tabIndex={0}
+                aria-sort={sortCol === 'ip' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+                onClick={() => handleSort('ip')}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort('ip'); } }}
+              >
+                IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                role="button"
+                tabIndex={0}
+                aria-sort={sortCol === 'open_ports' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+                onClick={() => handleSort('open_ports')}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort('open_ports'); } }}
+              >
+                Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                role="button"
+                tabIndex={0}
+                aria-sort={sortCol === 'mac' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+                onClick={() => handleSort('mac')}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort('mac'); } }}
+              >
+                MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -228,6 +228,11 @@ body {
   color: var(--text-highlight);
 }
 
+.cyber-table th:focus-visible {
+  outline: 2px solid var(--text-highlight);
+  outline-offset: -2px;
+}
+
 .cyber-table td {
   padding: 12px 16px;
   border-bottom: 1px solid rgba(69, 162, 158, 0.1);


### PR DESCRIPTION
💡 What: Added keyboard interactions (`onKeyDown`) and ARIA accessibility roles/attributes to the sortable table headers and the IP range input, and added a visual focus indicator for table headers.
🎯 Why: Improves accessibility by allowing keyboard-only users to trigger sorting (Enter/Space) and start scans directly from the input field (Enter), along with visual feedback on focused headers.
📸 Before/After: Added focus rings to headers and ability to sort/submit via keyboard.
♿ Accessibility: Improved keyboard navigation (`tabIndex`, `onKeyDown`) and screen reader context (`role="button"`, `aria-sort`).

---
*PR created automatically by Jules for task [13785424391991332091](https://jules.google.com/task/13785424391991332091) started by @mendsec*