### PR TITLE
🎨 Palette: Add keyboard accessibility to table headers and progress bar ARIA

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-24 - Interactive Table Headers Accessibility
+**Learning:** When creating custom interactive table headers (e.g. for sorting columns) that use `onClick`, they are opaque to screen readers and keyboard users. Native `<th>` elements do not receive focus or trigger events for Space/Enter natively.
+**Action:** Always add `tabIndex={0}` and an `onKeyDown` handler (for `Enter` and `Space` keys) to make them operable via keyboard. Additionally, add `aria-sort` (with values "ascending", "descending", or "none") and visual focus indicators (`:focus-visible` styling) so users know they are interactive and understand their current state.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -151,6 +151,27 @@ function App() {
     }
   };
 
+  const renderSortableHeader = (label: string, col: keyof results.HostResult) => {
+    const isSorted = sortCol === col;
+    const sortDirection = isSorted ? (sortAsc ? 'ascending' : 'descending') : 'none';
+
+    return (
+      <th
+        onClick={() => handleSort(col)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleSort(col);
+          }
+        }}
+        tabIndex={0}
+        aria-sort={sortDirection}
+      >
+        {label} {isSorted && (sortAsc ? '▲' : '▼')}
+      </th>
+    );
+  };
+
   return (
     <div className="app-container">
       {/* Header */}
@@ -195,7 +216,14 @@ function App() {
       </div>
 
       {isScanning && (
-        <div className="progress-container">
+        <div
+          className="progress-container"
+          role="progressbar"
+          aria-label="Scan progress"
+          aria-valuenow={Math.round(progress * 100)}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
           <div className="progress-bar" style={{ width: `${progress * 100}%` }}>
             <img src={nyanImg} alt="nyan" className="nyan-cat-img" />
           </div>
@@ -208,10 +236,10 @@ function App() {
           <thead>
             <tr>
               <th>Status</th>
-              <th onClick={() => handleSort('hostname')}>Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('ip')}>IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('open_ports')}>Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('mac')}>MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}</th>
+              {renderSortableHeader('Hostname', 'hostname')}
+              {renderSortableHeader('IP', 'ip')}
+              {renderSortableHeader('Ports', 'open_ports')}
+              {renderSortableHeader('MAC', 'mac')}
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -149,7 +149,8 @@ body {
 
 .cyber-btn:focus-visible,
 .icon-btn:focus-visible,
-.cyber-input:focus-visible {
+.cyber-input:focus-visible,
+.cyber-table th:focus-visible {
   outline: 2px solid var(--text-highlight);
   outline-offset: 2px;
 }


### PR DESCRIPTION
💡 **What:** Added keyboard interactivity (`tabIndex={0}`, `onKeyDown`) and screen reader feedback (`aria-sort`) to the sortable table headers, as well as `role="progressbar"` to the scan progress container. Also added a visible focus ring for table headers.
🎯 **Why:** Custom interactive `<th>` elements do not natively receive focus or fire `onClick` via keyboard, making them opaque to keyboard-only and screen reader users. The scanning progress bar also lacked necessary ARIA contexts.
📸 **Before/After:** See the generated screenshot/video illustrating the new visual focus indicator (cyan outline) when navigating the table headers via Tab.
♿ **Accessibility:** Users navigating by keyboard can now reach and interact with table headers. Screen readers will correctly interpret the current sort direction (`aria-sort`) and receive live updates about the progress bar's state.

---
*PR created automatically by Jules for task [14128401639807888168](https://jules.google.com/task/14128401639807888168) started by @mendsec*