### PR TITLE
🎨 Palette: Keyboard accessible sortable table headers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-08 - Keyboard Accessible Sortable Table Headers
+**Learning:** Custom sortable table headers (like those in `.cyber-table`) lack built-in accessibility features such as keyboard navigation and screen reader state indication.
+**Action:** Always add keyboard support (`tabIndex={0}`, `onKeyDown` handling 'Enter'/'Space'), focus styling (`:focus-visible`), and proper ARIA attributes (`role="columnheader"`, `aria-sort`) to custom sortable table headers.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -151,6 +151,29 @@ function App() {
     }
   };
 
+  const renderSortHeader = (col: keyof results.HostResult, label: string) => {
+    const isSorted = sortCol === col;
+    const sortDirection = sortAsc ? 'ascending' : 'descending';
+    const ariaSort = isSorted ? sortDirection : 'none';
+
+    return (
+      <th
+        onClick={() => handleSort(col)}
+        tabIndex={0}
+        role="columnheader"
+        aria-sort={ariaSort}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleSort(col);
+          }
+        }}
+      >
+        {label} {isSorted && (sortAsc ? '▲' : '▼')}
+      </th>
+    );
+  };
+
   return (
     <div className="app-container">
       {/* Header */}
@@ -208,10 +231,10 @@ function App() {
           <thead>
             <tr>
               <th>Status</th>
-              <th onClick={() => handleSort('hostname')}>Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('ip')}>IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('open_ports')}>Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('mac')}>MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}</th>
+              {renderSortHeader('hostname', 'Hostname')}
+              {renderSortHeader('ip', 'IP')}
+              {renderSortHeader('open_ports', 'Ports')}
+              {renderSortHeader('mac', 'MAC')}
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -224,8 +224,14 @@ body {
   text-align: left;
 }
 
-.cyber-table th:hover {
+.cyber-table th:hover,
+.cyber-table th:focus-visible {
   color: var(--text-highlight);
+}
+
+.cyber-table th:focus-visible {
+  outline: 2px solid var(--text-highlight);
+  outline-offset: -2px;
 }
 
 .cyber-table td {


### PR DESCRIPTION
💡 **What:** Added keyboard accessibility and ARIA attributes to the sortable table headers.
🎯 **Why:** Custom table headers were not accessible via keyboard or screen readers. This ensures they can be focused, navigated with the keyboard (Enter/Space), and understood by screen readers.
♿ **Accessibility:**
- Added `tabIndex={0}` to make the table headers focusable.
- Handled 'Enter' and 'Space' keypresses to trigger sorting.
- Added `role="columnheader"` and `aria-sort` to communicate sorting state to screen readers.
- Added `.cyber-table th:focus-visible` styling for visual focus indication.

---
*PR created automatically by Jules for task [6309788674829279159](https://jules.google.com/task/6309788674829279159) started by @mendsec*