### PR TITLE
🎨 Palette: Make table headers keyboard accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-06-09 - Sortable Table Header Accessibility
+**Learning:** Interactive custom components like `.cyber-table` sortable headers need manual accessibility features. Relying purely on `onClick` omits keyboard and screen reader users.
+**Action:** When creating sortable columns or interactive non-button elements, always implement `tabIndex={0}`, `onKeyDown` (for Enter/Space), `:focus-visible` styling, and appropriate ARIA attributes like `aria-sort`.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -208,10 +208,38 @@ function App() {
           <thead>
             <tr>
               <th>Status</th>
-              <th onClick={() => handleSort('hostname')}>Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('ip')}>IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('open_ports')}>Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('mac')}>MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}</th>
+              <th
+                onClick={() => handleSort('hostname')}
+                tabIndex={0}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort('hostname'); } }}
+                aria-sort={sortCol === 'hostname' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                onClick={() => handleSort('ip')}
+                tabIndex={0}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort('ip'); } }}
+                aria-sort={sortCol === 'ip' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                onClick={() => handleSort('open_ports')}
+                tabIndex={0}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort('open_ports'); } }}
+                aria-sort={sortCol === 'open_ports' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                onClick={() => handleSort('mac')}
+                tabIndex={0}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort('mac'); } }}
+                aria-sort={sortCol === 'mac' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -228,6 +228,11 @@ body {
   color: var(--text-highlight);
 }
 
+.cyber-table th[tabindex="0"]:focus-visible {
+  outline: 2px solid var(--text-highlight);
+  outline-offset: -2px;
+}
+
 .cyber-table td {
   padding: 12px 16px;
   border-bottom: 1px solid rgba(69, 162, 158, 0.1);


### PR DESCRIPTION
💡 What: Added `tabIndex={0}`, `onKeyDown` listeners (Enter and Space), and `aria-sort` attributes to the sortable columns in `.cyber-table`. Also added a `:focus-visible` rule in `index.css` to show a focus ring for keyboard navigation.
🎯 Why: Interactive elements relying only on `onClick` exclude users navigating by keyboard or screen readers. This allows sorting via keyboard and properly announces the sorting state.
♿ Accessibility: Ensures that sortable headers can be navigated to via the `Tab` key, activated via `Enter`/`Space`, and have their state announced properly to screen readers via `aria-sort`.

---
*PR created automatically by Jules for task [9570164735091794902](https://jules.google.com/task/9570164735091794902) started by @mendsec*