### PR TITLE
🎨 Palette: Add keyboard accessibility to sortable headers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-10 - Keyboard accessibility for sortable custom headers
+**Learning:** When turning non-interactive elements like `<th>` into interactive sortable headers, basic `onClick` handling is insufficient. Keyboard users cannot access them without `tabIndex={0}`, and they won't function with Space/Enter keys unless explicitly handled via `onKeyDown`. Additionally, screen readers need `role="button"` and `aria-sort` to communicate state.
+**Action:** Always add `tabIndex={0}`, `role="button"`, `aria-sort`, `onKeyDown` handlers, and `:focus-visible` styling when making custom UI elements like table headers interactive.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -208,10 +208,38 @@ function App() {
           <thead>
             <tr>
               <th>Status</th>
-              <th onClick={() => handleSort('hostname')}>Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('ip')}>IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('open_ports')}>Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('mac')}>MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}</th>
+              <th
+                tabIndex={0}
+                aria-sort={sortCol === 'hostname' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+                onClick={() => handleSort('hostname')}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort('hostname'); } }}
+              >
+                Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                tabIndex={0}
+                aria-sort={sortCol === 'ip' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+                onClick={() => handleSort('ip')}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort('ip'); } }}
+              >
+                IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                tabIndex={0}
+                aria-sort={sortCol === 'open_ports' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+                onClick={() => handleSort('open_ports')}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort('open_ports'); } }}
+              >
+                Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                tabIndex={0}
+                aria-sort={sortCol === 'mac' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+                onClick={() => handleSort('mac')}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort('mac'); } }}
+              >
+                MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -228,6 +228,11 @@ body {
   color: var(--text-highlight);
 }
 
+.cyber-table th:focus-visible {
+  outline: 2px solid var(--text-highlight);
+  outline-offset: -2px;
+}
+
 .cyber-table td {
   padding: 12px 16px;
   border-bottom: 1px solid rgba(69, 162, 158, 0.1);


### PR DESCRIPTION
💡 What: Added keyboard accessibility to the sortable table headers (`<th>`).
🎯 Why: Previously, keyboard users could not tab to or activate the column sorting, and screen reader users were not informed of the current sort state.
♿ Accessibility: Added `tabIndex={0}`, `onKeyDown` handlers for Enter/Space keys, `aria-sort` state management, and `:focus-visible` styling for a clear visual focus indicator.

---
*PR created automatically by Jules for task [12709537503310796273](https://jules.google.com/task/12709537503310796273) started by @mendsec*