### PR TITLE
🎨 Palette: Enhance Accessibility of Sortable Table Headers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,5 @@
+## 2024-06-12 - Accessible Sortable Table Headers
+
+**Learning:** When making `<th>` headers interactive for sorting in React/TypeScript, adding `role="button"` overrides the native `columnheader` role, which invalidates the `aria-sort` attribute for screen readers.
+
+**Action:** To maintain accessibility, keep the native `<th>` element without overriding the role. Instead, manually add interactivity using `tabIndex={0}`, an `onKeyDown` handler (for `Enter` and `Space` keys), and the `aria-sort` attribute. Use CSS attribute selectors (e.g., `th[aria-sort]`) to apply interactive styles and focus outlines only to sortable headers.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -208,10 +208,38 @@ function App() {
           <thead>
             <tr>
               <th>Status</th>
-              <th onClick={() => handleSort('hostname')}>Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('ip')}>IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('open_ports')}>Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('mac')}>MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}</th>
+              <th
+                onClick={() => handleSort('hostname')}
+                tabIndex={0}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort('hostname'); } }}
+                aria-sort={sortCol === 'hostname' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                onClick={() => handleSort('ip')}
+                tabIndex={0}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort('ip'); } }}
+                aria-sort={sortCol === 'ip' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                onClick={() => handleSort('open_ports')}
+                tabIndex={0}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort('open_ports'); } }}
+                aria-sort={sortCol === 'open_ports' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                onClick={() => handleSort('mac')}
+                tabIndex={0}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort('mac'); } }}
+                aria-sort={sortCol === 'mac' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -219,13 +219,21 @@ body {
   position: sticky;
   top: 0;
   z-index: 10;
-  cursor: pointer;
-  user-select: none;
   text-align: left;
 }
 
-.cyber-table th:hover {
+.cyber-table th[aria-sort] {
+  cursor: pointer;
+  user-select: none;
+}
+
+.cyber-table th[aria-sort]:hover {
   color: var(--text-highlight);
+}
+
+.cyber-table th[aria-sort]:focus-visible {
+  outline: 2px solid var(--text-highlight);
+  outline-offset: -2px;
 }
 
 .cyber-table td {


### PR DESCRIPTION
💡 **What**: Added `tabIndex={0}`, keyboard navigation (Enter/Space to sort), and `aria-sort` attributes to the sortable columns in the main data table (`App.tsx`). Updated `index.css` to properly show the interactive pointers and focus states only on sortable columns.
🎯 **Why**: Previously, the table headers could only be sorted via a mouse click, making them inaccessible to keyboard and screen reader users. The `Status` column was non-sortable but still displayed a pointer cursor, confusing users.
📸 **Before/After**: The table headers are now accessible via keyboard, indicate focus outline, and broadcast their current sort direction (`aria-sort`) to screen readers properly.
♿ **Accessibility**: Preserved the native `<th>` `columnheader` role while adding missing interaction hooks and ARIA attributes for sort state indication. Ensure hover effects and keyboard interactions only apply to sortable fields.

---
*PR created automatically by Jules for task [13189426127028210423](https://jules.google.com/task/13189426127028210423) started by @mendsec*