### PR TITLE
🎨 Palette: Improve accessibility of sortable table headers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-13 - Interactive Table Header Accessibility Constraints
+**Learning:** When making `<th>` elements interactive (e.g., for sortable columns), adding `role="button"` directly to the `<th>` destroys its native semantic role (`columnheader`). This native role is required for the `aria-sort` attribute to be valid and interpreted correctly by screen readers.
+**Action:** Always avoid `role="button"` on `<th>`. Instead, rely on native focus mechanisms (`tabIndex={0}`), custom keyboard event handlers (`onKeyDown`), visible focus styles (`:focus-visible`), and properly updated `aria-sort` values.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -208,10 +208,38 @@ function App() {
           <thead>
             <tr>
               <th>Status</th>
-              <th onClick={() => handleSort('hostname')}>Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('ip')}>IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('open_ports')}>Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('mac')}>MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}</th>
+              <th
+                onClick={() => handleSort('hostname')}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort('hostname'); } }}
+                tabIndex={0}
+                aria-sort={sortCol === 'hostname' ? (sortAsc ? "ascending" : "descending") : "none"}
+              >
+                Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                onClick={() => handleSort('ip')}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort('ip'); } }}
+                tabIndex={0}
+                aria-sort={sortCol === 'ip' ? (sortAsc ? "ascending" : "descending") : "none"}
+              >
+                IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                onClick={() => handleSort('open_ports')}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort('open_ports'); } }}
+                tabIndex={0}
+                aria-sort={sortCol === 'open_ports' ? (sortAsc ? "ascending" : "descending") : "none"}
+              >
+                Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                onClick={() => handleSort('mac')}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort('mac'); } }}
+                tabIndex={0}
+                aria-sort={sortCol === 'mac' ? (sortAsc ? "ascending" : "descending") : "none"}
+              >
+                MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -228,6 +228,12 @@ body {
   color: var(--text-highlight);
 }
 
+.cyber-table th:focus-visible {
+  color: var(--text-highlight);
+  outline: 2px solid var(--text-highlight);
+  outline-offset: -2px;
+}
+
 .cyber-table td {
   padding: 12px 16px;
   border-bottom: 1px solid rgba(69, 162, 158, 0.1);


### PR DESCRIPTION
💡 **What:** The UX enhancement added is making the sortable table columns keyboard-accessible and screen-reader friendly.
🎯 **Why:** Previously, users relying on keyboards or assistive technology could not easily identify or activate column sorting. This ensures all users can navigate the data effectively.
📸 **Before/After:** Table headers now exhibit a clear `:focus-visible` ring during keyboard navigation and respond to `Enter` and `Space` key presses.
♿ **Accessibility:**
- Added `tabIndex={0}` to make headers focusable.
- Added an `onKeyDown` handler to allow sorting via `Enter` or `Space` (with `e.preventDefault()` to stop spacebar from scrolling the page).
- Added `aria-sort` to announce the sort direction.
- Maintained the native semantic `columnheader` role by explicitly avoiding adding `role="button"`.

---
*PR created automatically by Jules for task [6543688292945826517](https://jules.google.com/task/6543688292945826517) started by @mendsec*