### PR TITLE
🎨 Palette: Improve accessibility of table sort headers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-15 - Interactive Table Header Accessibility
+**Learning:** React/TypeScript custom table headers (`<th onClick>`) acting as sort buttons are completely invisible to keyboard navigation and screen readers without manual accessibility wiring. Using `role="button"` on `<th>` overrides its native `columnheader` role, which invalidates the `aria-sort` attribute needed for conveying sort state.
+**Action:** When making custom table headers interactive, explicitly add `tabIndex={0}`, an `onKeyDown` handler (listening for 'Enter'/' '), and a dynamic `aria-sort` attribute ('ascending'|'descending'|'none'). Ensure CSS provides a visible `:focus-visible` state.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, KeyboardEvent } from 'react';
 import './index.css';
 import { StartScan, StopScan, ParseRange, ExportResults, GetLocalIPRange } from '../wailsjs/go/main/App';
 import { EventsOn, EventsOff } from '../wailsjs/runtime/runtime';
@@ -121,6 +121,13 @@ function App() {
     }
   };
 
+  const handleSortKeyDown = (e: KeyboardEvent<HTMLTableCellElement>, col: keyof results.HostResult) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleSort(col);
+    }
+  };
+
   const sortedDevices = [...devices].sort((a, b) => {
     if (!sortCol) return 0;
     
@@ -208,10 +215,38 @@ function App() {
           <thead>
             <tr>
               <th>Status</th>
-              <th onClick={() => handleSort('hostname')}>Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('ip')}>IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('open_ports')}>Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('mac')}>MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}</th>
+              <th
+                onClick={() => handleSort('hostname')}
+                onKeyDown={(e) => handleSortKeyDown(e, 'hostname')}
+                tabIndex={0}
+                aria-sort={sortCol === 'hostname' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                onClick={() => handleSort('ip')}
+                onKeyDown={(e) => handleSortKeyDown(e, 'ip')}
+                tabIndex={0}
+                aria-sort={sortCol === 'ip' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                onClick={() => handleSort('open_ports')}
+                onKeyDown={(e) => handleSortKeyDown(e, 'open_ports')}
+                tabIndex={0}
+                aria-sort={sortCol === 'open_ports' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                onClick={() => handleSort('mac')}
+                onKeyDown={(e) => handleSortKeyDown(e, 'mac')}
+                tabIndex={0}
+                aria-sort={sortCol === 'mac' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -228,6 +228,11 @@ body {
   color: var(--text-highlight);
 }
 
+.cyber-table th:focus-visible {
+  outline: 2px solid var(--text-highlight);
+  outline-offset: -2px;
+}
+
 .cyber-table td {
   padding: 12px 16px;
   border-bottom: 1px solid rgba(69, 162, 158, 0.1);


### PR DESCRIPTION
💡 What: The UX enhancement added keyboard accessibility and screen reader support to the interactive table column headers.

🎯 Why: The custom sortable table headers (`<th>` with `onClick`) were previously unreachable by keyboard users and did not convey their interactive nature or current sort state to screen readers.

📸 Before/After: Visual `:focus-visible` outline added around the header text when focused via the `Tab` key.

♿ Accessibility: Added `tabIndex={0}`, `onKeyDown` handling for Enter/Space, dynamic `aria-sort` attributes, and visual focus indicators.

---
*PR created automatically by Jules for task [4709175580578765079](https://jules.google.com/task/4709175580578765079) started by @mendsec*