### PR TITLE
🎨 Palette: Add keyboard accessibility to sortable table headers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-16 - Accessibility of interactive custom components (<th>)
+**Learning:** When making table header cells (`<th>`) interactive for sorting purposes, adding `role="button"` directly to the `<th>` elements overrides the native `columnheader` role. This invalidates the `aria-sort` attribute which is critical for screen reader compatibility for sortable tables.
+**Action:** Instead of modifying the role, simply manually implement accessibility features including `tabIndex={0}`, `onKeyDown` (handling both Enter and Space keys to mimic button behavior), `:focus-visible` styling, and `aria-sort` directly on the `<th>` elements. This preserves the table semantics while maintaining interactivity.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import type { KeyboardEvent } from 'react';
 import './index.css';
 import { StartScan, StopScan, ParseRange, ExportResults, GetLocalIPRange } from '../wailsjs/go/main/App';
 import { EventsOn, EventsOff } from '../wailsjs/runtime/runtime';
@@ -121,6 +122,20 @@ function App() {
     }
   };
 
+  const handleKeyDownSort = (e: KeyboardEvent<HTMLTableCellElement>, col: keyof results.HostResult) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleSort(col);
+    }
+  };
+
+  const getAriaSort = (col: keyof results.HostResult) => {
+    if (sortCol === col) {
+      return sortAsc ? 'ascending' : 'descending';
+    }
+    return 'none';
+  };
+
   const sortedDevices = [...devices].sort((a, b) => {
     if (!sortCol) return 0;
     
@@ -208,10 +223,38 @@ function App() {
           <thead>
             <tr>
               <th>Status</th>
-              <th onClick={() => handleSort('hostname')}>Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('ip')}>IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('open_ports')}>Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('mac')}>MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}</th>
+              <th
+                tabIndex={0}
+                onClick={() => handleSort('hostname')}
+                onKeyDown={(e) => handleKeyDownSort(e, 'hostname')}
+                aria-sort={getAriaSort('hostname')}
+              >
+                Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                tabIndex={0}
+                onClick={() => handleSort('ip')}
+                onKeyDown={(e) => handleKeyDownSort(e, 'ip')}
+                aria-sort={getAriaSort('ip')}
+              >
+                IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                tabIndex={0}
+                onClick={() => handleSort('open_ports')}
+                onKeyDown={(e) => handleKeyDownSort(e, 'open_ports')}
+                aria-sort={getAriaSort('open_ports')}
+              >
+                Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                tabIndex={0}
+                onClick={() => handleSort('mac')}
+                onKeyDown={(e) => handleKeyDownSort(e, 'mac')}
+                aria-sort={getAriaSort('mac')}
+              >
+                MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -149,7 +149,8 @@ body {
 
 .cyber-btn:focus-visible,
 .icon-btn:focus-visible,
-.cyber-input:focus-visible {
+.cyber-input:focus-visible,
+.cyber-table th:focus-visible {
   outline: 2px solid var(--text-highlight);
   outline-offset: 2px;
 }


### PR DESCRIPTION
💡 What: Added `tabIndex={0}`, `onKeyDown` handlers for Space/Enter keys, and `aria-sort` attributes to the sortable table headers in `App.tsx`. Updated `.cyber-table th:focus-visible` to use the existing focus outline styling.
🎯 Why: To allow keyboard users to focus and trigger sorting on the table headers, and to inform screen reader users of the current sort state without overriding the native `columnheader` role.
♿ Accessibility: Ensures full keyboard navigability (tabbing and Enter/Space to sort) and screen reader support (via `aria-sort`) for the data table.
📸 Before/After: Visual focus state (cyan outline) is now visible when tabbing through table headers.

---
*PR created automatically by Jules for task [12553185998398794146](https://jules.google.com/task/12553185998398794146) started by @mendsec*