### PR TITLE
🎨 Palette: Improve table header accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-10-24 - Interactive Custom Component Accessibility
+**Learning:** When making custom `.cyber-table` sortable `<th>` elements interactive, adding `role="button"` overrides the native `columnheader` role, which invalidates the `aria-sort` attribute in screen readers.
+**Action:** Do not use `role="button"` on `<th>` elements. Instead, rely on `tabIndex={0}`, manual `onKeyDown` (Enter/Space) handling, and `aria-sort` to ensure screen reader compatibility while maintaining keyboard accessibility. Ensure `:focus-visible` styling is appended to existing selectors to maintain visual design consistency without introducing rogue custom CSS.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, KeyboardEvent } from 'react';
 import './index.css';
 import { StartScan, StopScan, ParseRange, ExportResults, GetLocalIPRange } from '../wailsjs/go/main/App';
 import { EventsOn, EventsOff } from '../wailsjs/runtime/runtime';
@@ -121,6 +121,13 @@ function App() {
     }
   };
 
+  const handleSortKeyDown = (e: KeyboardEvent<HTMLTableCellElement>, col: keyof results.HostResult) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleSort(col);
+    }
+  };
+
   const sortedDevices = [...devices].sort((a, b) => {
     if (!sortCol) return 0;
     
@@ -208,10 +215,38 @@ function App() {
           <thead>
             <tr>
               <th>Status</th>
-              <th onClick={() => handleSort('hostname')}>Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('ip')}>IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('open_ports')}>Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('mac')}>MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}</th>
+              <th
+                tabIndex={0}
+                onClick={() => handleSort('hostname')}
+                onKeyDown={(e) => handleSortKeyDown(e, 'hostname')}
+                aria-sort={sortCol === 'hostname' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                tabIndex={0}
+                onClick={() => handleSort('ip')}
+                onKeyDown={(e) => handleSortKeyDown(e, 'ip')}
+                aria-sort={sortCol === 'ip' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                tabIndex={0}
+                onClick={() => handleSort('open_ports')}
+                onKeyDown={(e) => handleSortKeyDown(e, 'open_ports')}
+                aria-sort={sortCol === 'open_ports' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                tabIndex={0}
+                onClick={() => handleSort('mac')}
+                onKeyDown={(e) => handleSortKeyDown(e, 'mac')}
+                aria-sort={sortCol === 'mac' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -147,6 +147,7 @@ body {
   pointer-events: auto; /* Required to show tooltips on disabled buttons */
 }
 
+.cyber-table th:focus-visible,
 .cyber-btn:focus-visible,
 .icon-btn:focus-visible,
 .cyber-input:focus-visible {


### PR DESCRIPTION
💡 **What**: Made the sortable table headers (`<th>`) keyboard focusable and actionable, including proper screen reader ARIA attributes and visual focus rings.
🎯 **Why**: Keyboard-only and screen-reader users could not interact with or sort the results table.
♿ **Accessibility**: Added `tabIndex="0"`, custom `onKeyDown` handler for Space/Enter, dynamic `aria-sort` attributes (`ascending`/`descending`/`none`), and a visible focus ring using existing design tokens.

---
*PR created automatically by Jules for task [11393747002536286522](https://jules.google.com/task/11393747002536286522) started by @mendsec*