### PR TITLE
🎨 Palette: Make sortable table headers keyboard accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,5 @@
+# Palette's UX Journal
+
+## 2026-06-19 - [Accessibility] Accessible Table Sort Headers
+**Learning:** React elements serving as interactive table headers (e.g., `<th>` with an onClick handler for sorting) require manual implementation of keyboard accessibility properties including `tabIndex={0}` and an `onKeyDown` handler to actuate actions on 'Enter' and 'Space'. Applying semantic `aria-sort` attributes correctly is necessary, as is adding `:focus-visible` styling specifically for the `<th>` tags so that visual focus representation occurs naturally without conflicting custom CSS.
+**Action:** When adding interactivity to non-interactive elements, ensure comprehensive keyboard handlers, tabindexing, visible focus styling, and correct semantic ARIA properties are defined immediately.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, KeyboardEvent } from 'react';
 import './index.css';
 import { StartScan, StopScan, ParseRange, ExportResults, GetLocalIPRange } from '../wailsjs/go/main/App';
 import { EventsOn, EventsOff } from '../wailsjs/runtime/runtime';
@@ -121,6 +121,13 @@ function App() {
     }
   };
 
+  const handleKeyDownSort = (e: KeyboardEvent<HTMLTableCellElement>, col: keyof results.HostResult) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleSort(col);
+    }
+  };
+
   const sortedDevices = [...devices].sort((a, b) => {
     if (!sortCol) return 0;
     
@@ -208,10 +215,38 @@ function App() {
           <thead>
             <tr>
               <th>Status</th>
-              <th onClick={() => handleSort('hostname')}>Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('ip')}>IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('open_ports')}>Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('mac')}>MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}</th>
+              <th
+                onClick={() => handleSort('hostname')}
+                onKeyDown={(e) => handleKeyDownSort(e, 'hostname')}
+                tabIndex={0}
+                aria-sort={sortCol === 'hostname' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                onClick={() => handleSort('ip')}
+                onKeyDown={(e) => handleKeyDownSort(e, 'ip')}
+                tabIndex={0}
+                aria-sort={sortCol === 'ip' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                onClick={() => handleSort('open_ports')}
+                onKeyDown={(e) => handleKeyDownSort(e, 'open_ports')}
+                tabIndex={0}
+                aria-sort={sortCol === 'open_ports' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                onClick={() => handleSort('mac')}
+                onKeyDown={(e) => handleKeyDownSort(e, 'mac')}
+                tabIndex={0}
+                aria-sort={sortCol === 'mac' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -149,7 +149,8 @@ body {
 
 .cyber-btn:focus-visible,
 .icon-btn:focus-visible,
-.cyber-input:focus-visible {
+.cyber-input:focus-visible,
+.cyber-table th:focus-visible {
   outline: 2px solid var(--text-highlight);
   outline-offset: 2px;
 }


### PR DESCRIPTION
💡 What: Added keyboard accessibility to the sortable table headers in the devices list.
🎯 Why: Users navigating with keyboards could not sort the scanned devices because the table headers lacked a tabindex, keyboard event handlers, and focus visibility.
♿ Accessibility:
- Added `tabIndex={0}` to all sortable `<th>` elements.
- Implemented `onKeyDown` to trigger sort actions using 'Enter' or 'Space'.
- Added dynamic `aria-sort` semantic attributes indicating sort direction.
- Appended `th:focus-visible` styling to maintain a consistent keyboard focus ring.

---
*PR created automatically by Jules for task [8232402518389028487](https://jules.google.com/task/8232402518389028487) started by @mendsec*