### PR TITLE
🎨 Palette: Add keyboard accessibility and ARIA roles to sortable table headers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-20 - Custom Table Header Accessibility
+**Learning:** When modifying interactive custom components in the frontend (such as `.cyber-table` sortable headers), manually implement accessibility features including `tabIndex={0}`, `onKeyDown` (Enter/Space) handling, `:focus-visible` styling, and `aria-sort`. Do not add `role="button"` directly to `<th>` elements, as it overrides the native `columnheader` role and invalidates the `aria-sort` attribute.
+**Action:** When making custom components interactive, ensure all native accessibility roles are maintained or enhanced with ARIA attributes and keyboard interaction patterns.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, KeyboardEvent } from 'react';
 import './index.css';
 import { StartScan, StopScan, ParseRange, ExportResults, GetLocalIPRange } from '../wailsjs/go/main/App';
 import { EventsOn, EventsOff } from '../wailsjs/runtime/runtime';
@@ -208,10 +208,38 @@ function App() {
           <thead>
             <tr>
               <th>Status</th>
-              <th onClick={() => handleSort('hostname')}>Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('ip')}>IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('open_ports')}>Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('mac')}>MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}</th>
+              <th
+                onClick={() => handleSort('hostname')}
+                onKeyDown={(e: KeyboardEvent) => (e.key === 'Enter' || e.key === ' ') && handleSort('hostname')}
+                tabIndex={0}
+                aria-sort={sortCol === 'hostname' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                onClick={() => handleSort('ip')}
+                onKeyDown={(e: KeyboardEvent) => (e.key === 'Enter' || e.key === ' ') && handleSort('ip')}
+                tabIndex={0}
+                aria-sort={sortCol === 'ip' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                onClick={() => handleSort('open_ports')}
+                onKeyDown={(e: KeyboardEvent) => (e.key === 'Enter' || e.key === ' ') && handleSort('open_ports')}
+                tabIndex={0}
+                aria-sort={sortCol === 'open_ports' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                onClick={() => handleSort('mac')}
+                onKeyDown={(e: KeyboardEvent) => (e.key === 'Enter' || e.key === ' ') && handleSort('mac')}
+                tabIndex={0}
+                aria-sort={sortCol === 'mac' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -149,7 +149,8 @@ body {
 
 .cyber-btn:focus-visible,
 .icon-btn:focus-visible,
-.cyber-input:focus-visible {
+.cyber-input:focus-visible,
+.cyber-table th:focus-visible {
   outline: 2px solid var(--text-highlight);
   outline-offset: 2px;
 }


### PR DESCRIPTION
💡 What: Added keyboard navigation, ARIA sort roles, and visible focus states to the sortable table headers (`.cyber-table th`).
🎯 Why: Previously, sorting could only be performed via mouse clicks. This change makes the table accessible to keyboard users (via Tab to focus and Enter/Space to activate) and screen reader users (via `aria-sort`), solving a significant accessibility barrier.
📸 Before/After: Visual changes only involve adding a high-contrast focus ring (`:focus-visible`) when navigating the headers via keyboard.
♿ Accessibility: Improved semantic markup and fully enabled keyboard control for table interaction.

---
*PR created automatically by Jules for task [6029757133008212324](https://jules.google.com/task/6029757133008212324) started by @mendsec*