### PR TITLE
🎨 Palette: Make table headers keyboard accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-21 - Preserving native roles for sortable table headers
+**Learning:** When making `<th>` elements interactive (sortable) for keyboard users, do not add `role="button"`. Doing so overrides the native `columnheader` role, which invalidates the `aria-sort` attribute needed by screen readers.
+**Action:** Implement interactivity manually on `<th>` elements using `tabIndex={0}` and `onKeyDown` (handling Enter and Space), rather than changing the role, to maintain full accessibility.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, KeyboardEvent } from 'react';
 import './index.css';
 import { StartScan, StopScan, ParseRange, ExportResults, GetLocalIPRange } from '../wailsjs/go/main/App';
 import { EventsOn, EventsOff } from '../wailsjs/runtime/runtime';
@@ -121,6 +121,13 @@ function App() {
     }
   };
 
+  const handleSortKeyDown = (e: KeyboardEvent<HTMLTableCellElement>, col: keyof results.HostResult) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleSort(col);
+    }
+  };
+
   const sortedDevices = [...devices].sort((a, b) => {
     if (!sortCol) return 0;
     
@@ -208,10 +215,38 @@ function App() {
           <thead>
             <tr>
               <th>Status</th>
-              <th onClick={() => handleSort('hostname')}>Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('ip')}>IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('open_ports')}>Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('mac')}>MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}</th>
+              <th
+                onClick={() => handleSort('hostname')}
+                onKeyDown={(e) => handleSortKeyDown(e, 'hostname')}
+                tabIndex={0}
+                aria-sort={sortCol === 'hostname' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                onClick={() => handleSort('ip')}
+                onKeyDown={(e) => handleSortKeyDown(e, 'ip')}
+                tabIndex={0}
+                aria-sort={sortCol === 'ip' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                onClick={() => handleSort('open_ports')}
+                onKeyDown={(e) => handleSortKeyDown(e, 'open_ports')}
+                tabIndex={0}
+                aria-sort={sortCol === 'open_ports' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}
+              </th>
+              <th
+                onClick={() => handleSort('mac')}
+                onKeyDown={(e) => handleSortKeyDown(e, 'mac')}
+                tabIndex={0}
+                aria-sort={sortCol === 'mac' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >
+                MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -149,7 +149,8 @@ body {
 
 .cyber-btn:focus-visible,
 .icon-btn:focus-visible,
-.cyber-input:focus-visible {
+.cyber-input:focus-visible,
+.cyber-table th:focus-visible {
   outline: 2px solid var(--text-highlight);
   outline-offset: 2px;
 }


### PR DESCRIPTION
💡 **What**: Added keyboard accessibility to the sortable `.cyber-table` column headers.
🎯 **Why**: Users navigating via keyboard could not interact with the column headers to sort the table data. This change allows users to focus on headers via `Tab` and toggle sorting using `Enter` or `Space`, providing a full equivalent to the mouse click interaction.
📸 **Before/After**: Screenshots included in UI verification show visual focus outlines on table headers (`<th>`) upon keyboard navigation.
♿ **Accessibility**: 
- Added `tabIndex={0}` to all sortable headers.
- Implemented `onKeyDown` handlers for `Enter` and `Space`.
- Maintained native `columnheader` role while adding the `aria-sort` attribute (dynamically reflecting 'ascending', 'descending', or 'none').
- Appended `th:focus-visible` to existing styles to show focus rings without adding new custom design rules.
- Logged UX learning regarding preserving native `columnheader` roles to `.jules/palette.md`.

---
*PR created automatically by Jules for task [8638681538185025707](https://jules.google.com/task/8638681538185025707) started by @mendsec*