### PR TITLE
🎨 Palette: Make table headers keyboard accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Prevent Default on Space Keydown handlers
+**Learning:** When adding keyboard accessibility to interactive components like table headers that use custom `onKeyDown` handlers for `Enter` and `Space` keys, failing to call `e.preventDefault()` on the spacebar keydown event allows the default browser behavior (scrolling the page down) to trigger, ruining the user experience.
+**Action:** Always include `e.preventDefault()` in custom keydown handlers for the `Space` key on interactive custom UI components.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, KeyboardEvent } from 'react';
 import './index.css';
 import { StartScan, StopScan, ParseRange, ExportResults, GetLocalIPRange } from '../wailsjs/go/main/App';
 import { EventsOn, EventsOff } from '../wailsjs/runtime/runtime';
@@ -208,10 +208,30 @@ function App() {
           <thead>
             <tr>
               <th>Status</th>
-              <th onClick={() => handleSort('hostname')}>Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('ip')}>IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('open_ports')}>Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}</th>
-              <th onClick={() => handleSort('mac')}>MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}</th>
+              <th
+                onClick={() => handleSort('hostname')}
+                tabIndex={0}
+                onKeyDown={(e: KeyboardEvent<HTMLTableCellElement>) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort('hostname'); } }}
+                aria-sort={sortCol === 'hostname' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}</th>
+              <th
+                onClick={() => handleSort('ip')}
+                tabIndex={0}
+                onKeyDown={(e: KeyboardEvent<HTMLTableCellElement>) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort('ip'); } }}
+                aria-sort={sortCol === 'ip' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}</th>
+              <th
+                onClick={() => handleSort('open_ports')}
+                tabIndex={0}
+                onKeyDown={(e: KeyboardEvent<HTMLTableCellElement>) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort('open_ports'); } }}
+                aria-sort={sortCol === 'open_ports' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}</th>
+              <th
+                onClick={() => handleSort('mac')}
+                tabIndex={0}
+                onKeyDown={(e: KeyboardEvent<HTMLTableCellElement>) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort('mac'); } }}
+                aria-sort={sortCol === 'mac' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+              >MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}</th>
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -149,7 +149,8 @@ body {
 
 .cyber-btn:focus-visible,
 .icon-btn:focus-visible,
-.cyber-input:focus-visible {
+.cyber-input:focus-visible,
+.cyber-table th[tabIndex="0"]:focus-visible {
   outline: 2px solid var(--text-highlight);
   outline-offset: 2px;
 }


### PR DESCRIPTION
💡 What: Added keyboard accessibility to the sortable table headers.
🎯 Why: Users navigating via keyboard could not trigger table sorting or see which column header had focus, preventing them from fully interacting with the data table.
📸 Before/After: Visual outline is added on focus-visible. Screen readers can now announce the sorted states.
♿ Accessibility:
- Added `tabIndex={0}` to all sortable `<th>` elements.
- Implemented `onKeyDown` to trigger the `handleSort` function on `Enter` or `Space` key presses, making sure to prevent default scroll behavior.
- Added `aria-sort` correctly setting state to `ascending`, `descending`, or `none`.
- Enabled focus outline styles when the headers are focused via keyboard.

---
*PR created automatically by Jules for task [535613003707930244](https://jules.google.com/task/535613003707930244) started by @mendsec*