### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 0 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   govulncheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mendsec/catnet-scanner/security/code-scanning/1](https://github.com/mendsec/catnet-scanner/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is constrained to least privilege.  
Best fix here: define workflow-level permissions with `contents: read` (sufficient for checkout and read-only operations), since this workflow has a single job and no write operations are shown.

**Where to change:** `.github/workflows/govulncheck.yml`, after the `on:` triggers block and before `jobs:`.  
**What to add:**  
```yml
permissions:
  contents: read
```
No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
