### PR TITLE
chore: update catnet-core to v0.3.0 and remove replace directive

### DIFF
--- a/docs/ci_troubleshooting/fetch_all_prs.py
+++ b/docs/ci_troubleshooting/fetch_all_prs.py
@@ -6,7 +6,7 @@ req = urllib.request.Request(url)
 req.add_header('User-Agent', 'Python-urllib/3.x')
 
 try:
-    with urllib.request.urlopen(req) as response:
+    with urllib.request.urlopen(req) as response: # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
         data = json.loads(response.read().decode())
         with open('docs/ci_troubleshooting/PR_HISTORY.md', 'w', encoding='utf-8') as f:
             f.write("# Histórico de Pull Requests\n\n")

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/leaanthony/u v1.1.1 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mendsec/catnet-core v0.0.0
+	github.com/mendsec/catnet-core v0.3.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
@@ -35,5 +35,3 @@ require (
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 )
-
-replace github.com/mendsec/catnet-core => ../catnet-core

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mendsec/catnet-core v0.3.0 h1:bi3HuBu9ixk3DEi+Ro0UChWmLpLce5ST+Gjy/FS0bwM=
+github.com/mendsec/catnet-core v0.3.0/go.mod h1:FmUGOcmzAc0ItyWvIWG43kRfqyEkxdDgqB35KdN85JU=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
Conclui a Fase 0 do roadmap atualizando o catnet-core para v0.3.0 e removendo as diretivas locais.