### PR TITLE
🎨 Palette: Add tooltip and ARIA label to status dots

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2023-10-25 - Custom Table Header Accessibility
 **Learning:** When turning non-interactive elements (like `<th>`) into sortable/interactive controls in this application, they do not inherently receive focus or keyboard events. They lack default focus outlines, making it confusing for keyboard users to navigate. Applying `role="button"` directly on `<th>` overrides the native `columnheader` role, confusing screen readers.
 **Action:** When implementing custom interactivity on elements like `<th>`, manually assign `tabIndex={0}` to make it focusable, attach an `onKeyDown` handler to capture 'Enter' or 'Space' keys (and call `e.preventDefault()`), provide explicit focus visibility logic (e.g., `:focus-visible` CSS rules), and use ARIA properties like `aria-sort` to maintain semantic meaning without destroying native structure.
+
+## 2023-10-25 - Status Indicator Accessibility
+**Learning:** Purely visual CSS status indicators (like colored dots for 'Online' and 'Offline' states) are ignored by screen readers if they are implemented as empty `<span>` tags. Furthermore, sighted users might not immediately understand what the colors mean without a legend.
+**Action:** Always add `role="img"` or `role="status"`, a descriptive `aria-label` (e.g., "Device is online"), and a native `title` tooltip (e.g., "Online") to purely visual status elements to make them accessible and user-friendly for all.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -268,7 +268,12 @@ function App() {
             {sortedDevices.map((dev, i) => (
               <tr key={i}>
                 <td>
-                  <span className={`status-dot ${dev.alive ? 'status-alive' : 'status-dead'}`}></span>
+                  <span
+                    className={`status-dot ${dev.alive ? 'status-alive' : 'status-dead'}`}
+                    role="img"
+                    aria-label={dev.alive ? 'Device is online' : 'Device is offline'}
+                    title={dev.alive ? 'Online' : 'Offline'}
+                  ></span>
                 </td>
                 <td>{dev.hostname || '--'}</td>
                 <td>{dev.ip}</td>


### PR DESCRIPTION
💡 What: Added `role="img"`, `aria-label`, and `title` attributes to the purely visual colored status dot spans in the devices table.
🎯 Why: Purely visual CSS dots (red/green) are inaccessible to screen readers because they are empty spans. Additionally, sighted users might not intuitively know what the colors mean. Adding ARIA labels fixes the screen reader issue, and adding a `title` provides a native hover tooltip.
📸 Before/After: Sighted users can now hover over the dot to see an "Online" or "Offline" tooltip. Screen readers announce "Device is online" or "Device is offline" instead of ignoring the column content.
♿ Accessibility: Ensures non-text content (visual status indicator) has a text alternative.

---
*PR created automatically by Jules for task [6770244181866105120](https://jules.google.com/task/6770244181866105120) started by @mendsec*