### PR TITLE
🎨 Palette: Add aria-sort to table headers for accessibility

### DIFF
--- a/frontend/src/components/ScannerView.tsx
+++ b/frontend/src/components/ScannerView.tsx
@@ -194,16 +194,16 @@ export function ScannerView() {
           <thead>
             <tr>
               <th>Status</th>
-              <th onClick={() => handleSort('hostname')} onKeyDown={(e) => handleSortKeyDown(e, 'hostname')} tabIndex={0}>
+              <th onClick={() => handleSort('hostname')} onKeyDown={(e) => handleSortKeyDown(e, 'hostname')} tabIndex={0} aria-sort={sortCol === 'hostname' ? (sortAsc ? 'ascending' : 'descending') : 'none'}>
                 Hostname {sortCol === 'hostname' && (sortAsc ? '▲' : '▼')}
               </th>
-              <th onClick={() => handleSort('ip')} onKeyDown={(e) => handleSortKeyDown(e, 'ip')} tabIndex={0}>
+              <th onClick={() => handleSort('ip')} onKeyDown={(e) => handleSortKeyDown(e, 'ip')} tabIndex={0} aria-sort={sortCol === 'ip' ? (sortAsc ? 'ascending' : 'descending') : 'none'}>
                 IP {sortCol === 'ip' && (sortAsc ? '▲' : '▼')}
               </th>
-              <th onClick={() => handleSort('open_ports')} onKeyDown={(e) => handleSortKeyDown(e, 'open_ports')} tabIndex={0}>
+              <th onClick={() => handleSort('open_ports')} onKeyDown={(e) => handleSortKeyDown(e, 'open_ports')} tabIndex={0} aria-sort={sortCol === 'open_ports' ? (sortAsc ? 'ascending' : 'descending') : 'none'}>
                 Ports {sortCol === 'open_ports' && (sortAsc ? '▲' : '▼')}
               </th>
-              <th onClick={() => handleSort('mac')} onKeyDown={(e) => handleSortKeyDown(e, 'mac')} tabIndex={0}>
+              <th onClick={() => handleSort('mac')} onKeyDown={(e) => handleSortKeyDown(e, 'mac')} tabIndex={0} aria-sort={sortCol === 'mac' ? (sortAsc ? 'ascending' : 'descending') : 'none'}>
                 MAC {sortCol === 'mac' && (sortAsc ? '▲' : '▼')}
               </th>
             </tr>


### PR DESCRIPTION
💡 What: Added dynamic `aria-sort` attributes to the interactive table headers in the ScannerView component.
🎯 Why: To clearly convey the current sort state (ascending, descending, or none) to screen readers when users interact with the column headers.
♿ Accessibility: Ensures that sortable `<th>` controls explicitly announce their sort order for screen reader compatibility, following WAI-ARIA guidelines for custom interactive tables.

---
*PR created automatically by Jules for task [16057793720282101919](https://jules.google.com/task/16057793720282101919) started by @mendsec*