### PR TITLE
🎨 Palette: Add confirmation dialog for delete action

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2023-10-25 - Status Indicator Accessibility
 **Learning:** Purely visual CSS status indicators (like colored dots for 'Online' and 'Offline' states) are ignored by screen readers if they are implemented as empty `<span>` tags. Furthermore, sighted users might not immediately understand what the colors mean without a legend.
 **Action:** Always add `role="img"` or `role="status"`, a descriptive `aria-label` (e.g., "Device is online"), and a native `title` tooltip (e.g., "Online") to purely visual status elements to make them accessible and user-friendly for all.
+
+## 2023-10-25 - Confirmation Dialog for Destructive Actions
+**Learning:** Destructive actions, like deleting scan history, lack a confirmation step, which can lead to accidental data loss. Furthermore, icon-only buttons in table rows (e.g., Export, Delete) are lacking explicit `aria-label` attributes, making them inaccessible to screen readers.
+**Action:** Always include a `window.confirm` dialog or custom confirmation modal before executing destructive actions. Ensure icon-only buttons have descriptive `aria-label` attributes to provide context to assistive technologies.

--- a/frontend/src/components/HistoryView.tsx
+++ b/frontend/src/components/HistoryView.tsx
@@ -23,6 +23,9 @@ export function HistoryView({ onCompare }: { onCompare: (scanId: number) => void
   }, []);
 
   const handleDelete = async (id: number) => {
+    if (!window.confirm(`Are you sure you want to delete scan #${id}? This action cannot be undone.`)) {
+      return;
+    }
     try {
       await DeleteScan(id);
       fetchScans();
@@ -63,13 +66,13 @@ export function HistoryView({ onCompare }: { onCompare: (scanId: number) => void
                 <td><span className="status-dot status-alive"></span> {scan.alive_hosts}</td>
                 <td>{scan.total_hosts}</td>
                 <td style={{ display: 'flex', gap: '8px' }}>
-                  <button className="icon-btn" title="Compare against last scan" onClick={() => onCompare(scan.id)}>
+                  <button className="icon-btn" aria-label={`Compare scan #${scan.id}`} title="Compare against last scan" onClick={() => onCompare(scan.id)}>
                     <Play size={16} /> Diff
                   </button>
-                  <button className="icon-btn" title="Export JSON">
+                  <button className="icon-btn" aria-label={`Export scan #${scan.id}`} title="Export JSON">
                     <Download size={16} />
                   </button>
-                  <button className="icon-btn" style={{ color: 'var(--status-dead)' }} title="Delete" onClick={() => handleDelete(scan.id)}>
+                  <button className="icon-btn" aria-label={`Delete scan #${scan.id}`} style={{ color: 'var(--status-dead)' }} title="Delete" onClick={() => handleDelete(scan.id)}>
                     <Trash2 size={16} />
                   </button>
                 </td>


### PR DESCRIPTION
### 💡 What
Added a confirmation dialog to the delete action in the scan history view, and added missing `aria-label` attributes to the action buttons.
### 🎯 Why
Destructive actions without confirmation are a prime source of accidental data loss and user frustration. Furthermore, icon-only buttons are completely opaque to screen-reader users without appropriate labels.
### ♿ Accessibility
Added explicit `aria-label`s to the 'Compare', 'Export', and 'Delete' icon-only buttons in the history table rows so they are discoverable and intelligible to screen-reader users.

---
*PR created automatically by Jules for task [12197580576198466403](https://jules.google.com/task/12197580576198466403) started by @mendsec*