### PR TITLE
🎨 Palette: Add confirmation dialog for delete and ARIA labels for icon buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2023-10-25 - Status Indicator Accessibility
 **Learning:** Purely visual CSS status indicators (like colored dots for 'Online' and 'Offline' states) are ignored by screen readers if they are implemented as empty `<span>` tags. Furthermore, sighted users might not immediately understand what the colors mean without a legend.
 **Action:** Always add `role="img"` or `role="status"`, a descriptive `aria-label` (e.g., "Device is online"), and a native `title` tooltip (e.g., "Online") to purely visual status elements to make them accessible and user-friendly for all.
+
+## 2023-10-25 - Icon-only Buttons and Destructive Actions
+**Learning:** Icon-only buttons (like those for Export or Delete actions) often lack programmatic descriptions, causing accessibility issues for screen readers. Destructive actions without a confirmation mechanism can lead to accidental data loss.
+**Action:** Consistently add `aria-label` attributes to icon-only buttons to convey their purpose programmatically. For destructive actions (like deleting a scan), implement an intermediate confirmation step (such as `window.confirm`) to ensure user intent.

--- a/frontend/src/components/DiffView.tsx
+++ b/frontend/src/components/DiffView.tsx
@@ -52,7 +52,7 @@ export function DiffView({ scanId, onBack }: { scanId: number | null, onBack: ()
   return (
     <div className="diff-view">
       <div className="glass-panel header" style={{ padding: '15px 20px', marginBottom: '20px', display: 'flex', gap: '15px', alignItems: 'center' }}>
-        <button className="icon-btn" onClick={onBack} title="Back to History">
+        <button className="icon-btn" onClick={onBack} title="Back to History" aria-label="Back to History">
           <ArrowLeft size={20} />
         </button>
         <div className="header-title" style={{ fontSize: '1.2rem', display: 'flex', alignItems: 'center' }}>

--- a/frontend/src/components/HistoryView.tsx
+++ b/frontend/src/components/HistoryView.tsx
@@ -23,6 +23,9 @@ export function HistoryView({ onCompare }: { onCompare: (scanId: number) => void
   }, []);
 
   const handleDelete = async (id: number) => {
+    if (!window.confirm("Are you sure you want to delete this scan? This action cannot be undone.")) {
+      return;
+    }
     try {
       await DeleteScan(id);
       fetchScans();
@@ -66,10 +69,10 @@ export function HistoryView({ onCompare }: { onCompare: (scanId: number) => void
                   <button className="icon-btn" title="Compare against last scan" onClick={() => onCompare(scan.id)}>
                     <Play size={16} /> Diff
                   </button>
-                  <button className="icon-btn" title="Export JSON">
+                  <button className="icon-btn" title="Export JSON" aria-label="Export JSON">
                     <Download size={16} />
                   </button>
-                  <button className="icon-btn" style={{ color: 'var(--status-dead)' }} title="Delete" onClick={() => handleDelete(scan.id)}>
+                  <button className="icon-btn" style={{ color: 'var(--status-dead)' }} title="Delete" aria-label={`Delete scan ${scan.id}`} onClick={() => handleDelete(scan.id)}>
                     <Trash2 size={16} />
                   </button>
                 </td>

--- a/frontend/src/components/ScannerView.tsx
+++ b/frontend/src/components/ScannerView.tsx
@@ -165,7 +165,7 @@ export function ScannerView() {
               aria-invalid={!isValidIpRange(ipRange) && ipRange !== '' ? 'true' : 'false'}
               style={{ borderColor: !isValidIpRange(ipRange) && ipRange !== '' ? 'var(--status-dead)' : undefined }}
             />
-            <button className="icon-btn" onClick={handleAutoDetect} disabled={isScanning} title="Auto Detect Subnet">
+            <button className="icon-btn" onClick={handleAutoDetect} disabled={isScanning} title="Auto Detect Subnet" aria-label="Auto Detect Subnet">
               <Search size={16} />
             </button>
           </div>


### PR DESCRIPTION
💡 What: Added a `window.confirm` dialog before deleting a scan in `HistoryView.tsx` and added descriptive `aria-label` attributes to icon-only buttons across `ScannerView.tsx`, `HistoryView.tsx`, and `DiffView.tsx`.
🎯 Why: Prevents accidental data loss when clicking the delete button. Improves accessibility by allowing screen readers to programmatically understand the purpose of icon-only buttons.
📸 Before/After: Visual changes are transparent. Behaviorally, a standard browser dialog interrupts deletion, and screen readers will now announce "Export JSON", "Delete scan X", "Auto Detect Subnet", and "Back to History".
♿ Accessibility: Explicit `aria-label`s provided for icon-only action buttons.

---
*PR created automatically by Jules for task [6617179910360066326](https://jules.google.com/task/6617179910360066326) started by @mendsec*